### PR TITLE
Removing header validation for fspiop-uri when the source is the Swit…

### DIFF
--- a/Golden_Path.postman_collection.json
+++ b/Golden_Path.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "878342de-da0c-4dad-989f-9df2c2683d70",
+		"_postman_id": "b69a54c4-eeb5-4f93-bae5-7b237aa9c2e4",
 		"name": "Golden_Path",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -10907,9 +10907,9 @@
 									"                pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
 									"            });",
 									"            ",
-									"            pm.test(\"payerfsp fspiop-uri is empty\", function () {",
-									"                pm.expect(headers['fspiop-uri']).to.eql(undefined);",
-									"            });",
+									"            // pm.test(\"payerfsp fspiop-uri is empty\", function () {",
+									"            //     pm.expect(headers['fspiop-uri']).to.eql(undefined);",
+									"            // });",
 									"            ",
 									"            // pm.test(\"payerfsp fspiop-http-method is empty\", function () {",
 									"            //     pm.expect(headers['fspiop-http-method']).to.eql(undefined);",


### PR DESCRIPTION
…ch (if its not the Switch its just relayed without being stripped-off)

Please refer to :mojaloop/project/issues/733