### PR TITLE
Updated FSP Deploy script to run on AWS dev1 deployment. 

### DIFF
--- a/Golden_Path.postman_collection.json
+++ b/Golden_Path.postman_collection.json
@@ -1,778 +1,787 @@
 {
 	"info": {
-		"_postman_id": "4518de83-a06e-4172-91f3-27aa9ba13b76",
+		"_postman_id": "c11fcaf8-dd31-48e5-ad27-3fbf985e4cb0",
 		"name": "Golden_Path",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
-	"item": [{
-		"name": "p2p_money_transfer",
-		"item": [{
-			"name": "p2p_happy_path",
-			"item": [{
-				"name": "Add User - {{pathfinderMSISDN}} to payeefsp",
-				"event": [{
+	"item": [
+		{
+			"name": "p2p_money_transfer",
+			"item": [
+				{
+					"name": "p2p_happy_path",
+					"item": [
+						{
+							"name": "Add User - {{pathfinderMSISDN}} to payeefsp",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "e3f505ea-4c76-4c5c-944c-c9188b39b699",
+										"exec": [
+											"pm.environment.set('fullName', 'Siabelo Maroka');",
+											"pm.environment.set('firstName', 'Siabelo');",
+											"pm.environment.set('lastName', 'Maroka');",
+											"pm.environment.set('dob', '3/3/1973');",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a34ed0a6-ec7f-4147-8103-ec17cefcb9e7",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"party\": {\n        \"partyIdInfo\": {\n            \"partyIdType\": \"MSISDN\",\n            \"partyIdentifier\": \"{{pathfinderMSISDN}}\",\n            \"fspId\": \"{{payeefsp}}\"\n        },\n        \"name\": \"{{fullName}}\",\n        \"personalInfo\": {\n            \"complexName\": {\n                \"firstName\": \"{{firstName}}\",\n                \"lastName\": \"{{lastName}}\"\n            },\n            \"dateOfBirth\": \"{{dob}}\"\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{HOST_SIMULATOR}}/payeefsp/parties/MSISDN/{{pathfinderMSISDN}}",
+									"host": [
+										"{{HOST_SIMULATOR}}"
+									],
+									"path": [
+										"payeefsp",
+										"parties",
+										"MSISDN",
+										"{{pathfinderMSISDN}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get Party Receiver",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "decab794-66d7-4b03-b6da-4191441206a8",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"//Check data on payee side",
+											"setTimeout(function () {",
+											"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payeefsp/requests/\"+pm.variables.get(\"pathfinderMSISDN\"), function (err, response) {",
+											"       ",
+											"       if(response.responseSize !== 0) { ",
+											"       //Checking headers",
+											"        var headers = response.json().headers;",
+											"        pm.test(\"payeefsp fspiop-source is payerfsp\", function () {",
+											"            pm.expect(headers['fspiop-source']).to.eql('payerfsp');",
+											"        });",
+											"        ",
+											"        pm.test(\"payeefsp fspiop-destination is payeefsp\", function () {",
+											"            pm.expect(headers['fspiop-destination']).to.eql('payeefsp');",
+											"        });",
+											"        ",
+											"        pm.test(\"payeefsp content-type should be application/vnd.interoperability.parties+json;version=1.0\", function () {",
+											"            pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.parties+json;version=1.0');",
+											"        });",
+											"        ",
+											"        //pm.test(\"payeefsp accept should be application/vnd.interoperability.parties+json;version=1\", function () {",
+											"        //    pm.expect(headers['accept']).to.eql('should be application/vnd.interoperability.parties+json;version=1');",
+											"        //});",
+											"        ",
+											"        ",
+											"        ",
+											"        //Validate protected header inside Signature",
+											"        var {signature,protectedHeader} = JSON.parse(headers['fspiop-signature'])",
+											"        var decodedProtectedHeaders = JSON.parse(atob(protectedHeader))",
+											"        console.log('decodedProtectedHeaders:',decodedProtectedHeaders)",
+											"        ",
+											"        // pm.test(\"FSPIOP-Signature signature is returned\", function () {",
+											"        //     pm.expect(signature).to.eql(pm.environment.get(\"payeefsp-signature\"));",
+											"        // });",
+											"        ",
+											"        pm.test(\"FSPIOP-Signature Protected Header alg to be RS256\", function () {",
+											"            pm.expect(decodedProtectedHeaders['alg']).to.eql('RS256');",
+											"        });",
+											"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-URI to be /parties\", function () {",
+											"            pm.expect(decodedProtectedHeaders['FSPIOP-URI']).to.eql('/parties');",
+											"        });",
+											"        ",
+											"",
+											"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-HTTP-Method to be GET\", function () {",
+											"            pm.expect(decodedProtectedHeaders['FSPIOP-HTTP-Method']).to.eql('GET');",
+											"        });",
+											"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Source to be Payerfsp\", function () {",
+											"            pm.expect(decodedProtectedHeaders['FSPIOP-Source']).to.eql('payerfsp');",
+											"        });",
+											"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Destination to be payeefsp\", function () {",
+											"            pm.expect(decodedProtectedHeaders['FSPIOP-Destination']).to.eql('payeefsp');",
+											"        });",
+											"        pm.test(\"FSPIOP-Signature Protected Header Date is present\", function () {",
+											"            pm.expect(decodedProtectedHeaders['Date']).to.not.eql(undefined);",
+											"        });",
+											"       ",
+											"        pm.test(\"payeefsp FSPIOP-URI to be /parties\", function () {",
+											"            pm.expect(headers['fspiop-uri']).to.eql('/parties');",
+											"        });",
+											"        ",
+											"        pm.test(\"payeefsp fspiop-http-method is GET\", function () {",
+											"            pm.expect(headers['fspiop-http-method']).to.eql('GET');",
+											"        });",
+											"        ",
+											"        ",
+											"        ",
+											"       } else {",
+											"           pm.test(\"Parties FAILED - payeeFSP\", function () {",
+											"            throw new Error('Did not receive response');",
+											"           });",
+											"           ",
+											"       }",
+											"      ",
+											"    });",
+											"}, 4000)",
+											"",
+											"//Check data on payer side",
+											"setTimeout(function () {",
+											"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.variables.get(\"pathfinderMSISDN\"), function (err, response) {",
+											"       ",
+											"       if(response.responseSize !== 0) { ",
+											"       //Checking headers",
+											"        var headers = response.json().headers;",
+											"        pm.test(\"payerfsp fspiop-source is payeefsp\", function () {",
+											"            pm.expect(headers['fspiop-source']).to.eql('payeefsp');",
+											"        });",
+											"        ",
+											"        pm.test(\"payerfsp fspiop-destination is payerfsp\", function () {",
+											"            pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
+											"        });",
+											"        ",
+											"        pm.test(\"payerfsp content-type should be application/vnd.interoperability.parties+json;version=1.0\", function () {",
+											"            pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.parties+json;version=1.0');",
+											"        });",
+											"        ",
+											"        pm.test(\"payerfsp accept is empty\", function () {",
+											"            pm.expect(headers['accept']).to.eql(undefined);",
+											"        });",
+											"        ",
+											"        ",
+											"        ",
+											"        //Validate protected header inside Signature",
+											"        var {signature,protectedHeader} = JSON.parse(headers['fspiop-signature'])",
+											"        var decodedProtectedHeaders = JSON.parse(atob(protectedHeader))",
+											"        console.log('decodedProtectedHeaders:',decodedProtectedHeaders)",
+											"        ",
+											"        // pm.test(\"FSPIOP-Signature signature is returned\", function () {",
+											"        //     pm.expect(signature).to.eql(pm.environment.get(\"payeefsp-signature\"));",
+											"        // });",
+											"        ",
+											"        pm.test(\"FSPIOP-Signature Protected Header alg to be RS256\", function () {",
+											"            pm.expect(decodedProtectedHeaders['alg']).to.eql('RS256');",
+											"        });",
+											"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-URI to be /parties/MSISDN/\"+pm.environment.get(\"pathfinderMSISDN\"), function () {",
+											"            pm.expect(decodedProtectedHeaders['FSPIOP-URI']).to.eql('/parties/MSISDN/'+pm.environment.get(\"pathfinderMSISDN\"));",
+											"        });",
+											"        ",
+											"",
+											"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-HTTP-Method to be PUT\", function () {",
+											"            pm.expect(decodedProtectedHeaders['FSPIOP-HTTP-Method']).to.eql('PUT');",
+											"        });",
+											"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Source to be mojaloop-sdk\", function () {",
+											"            pm.expect(decodedProtectedHeaders['FSPIOP-Source']).to.eql('payeefsp');",
+											"        });",
+											"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Destination to be payerfsp\", function () {",
+											"            pm.expect(decodedProtectedHeaders['FSPIOP-Destination']).to.eql('payerfsp');",
+											"        });",
+											"        pm.test(\"FSPIOP-Signature Protected Header Date is present\", function () {",
+											"            pm.expect(decodedProtectedHeaders['Date']).to.not.eql(undefined);",
+											"        });",
+											"       ",
+											"        //pm.test(\"payerfsp FSPIOP-URI to be /parties/MSISDN/\"+pm.environment.get(\"pathfinderMSISDN\"), function () {",
+											"        //    pm.expect(headers['fspiop-uri']).to.eql('/parties/MSISDN/'+pm.environment.get(\"pathfinderMSISDN\"));",
+											"        //});",
+											"        ",
+											"        pm.test(\"payerfsp fspiop-http-method is PUT\", function () {",
+											"            pm.expect(headers['fspiop-http-method']).to.eql('PUT');",
+											"        });",
+											"        ",
+											"        //Checking data",
+											"        var jsonData = response.json().data;",
+											"       pm.test(\"Expected receiver first name is: \"+pm.variables.get(\"expectedFirstName\"), function () {",
+											"           pm.expect(jsonData.party.personalInfo.complexName.firstName).to.eql(pm.variables.get(\"expectedFirstName\"));",
+											"        });",
+											"        pm.test(\"Expected receiver last name is: \"+pm.variables.get(\"expectedLastName\"), function () {",
+											"          pm.expect(jsonData.party.personalInfo.complexName.lastName).to.eql(pm.variables.get(\"expectedLastName\"));",
+											"        });",
+											"        pm.test(\"Expected receiver DOB: \"+pm.variables.get(\"expectedDOB\"), function () {",
+											"          pm.expect(jsonData.party.personalInfo.dateOfBirth).to.eql(pm.variables.get(\"expectedDOB\"));",
+											"        });  ",
+											"        ",
+											"       } else {",
+											"           pm.test(\"Parties FAILED - payerFSP\", function () {",
+											"            throw new Error('Did not receive response');",
+											"           });",
+											"           ",
+											"       }",
+											"      ",
+											"    });",
+											"}, 4000)",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "c0e9b1b6-9f17-42f4-b7aa-9317535a62b7",
+										"exec": [
+											"pm.variables.set('expectedFullName', 'Siabelo Maroka');",
+											"pm.variables.set('expectedFirstName', 'Siabelo');",
+											"pm.variables.set('expectedLastName', 'Maroka');",
+											"pm.variables.set('expectedDOB', '3/3/1973');",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.parties+json;version=1",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.parties+json;version=1.0",
+										"type": "text"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}",
+										"type": "text"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"value": "{{payeefsp}}",
+										"type": "text"
+									},
+									{
+										"key": "Date",
+										"value": "{{dateHeader}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_ACCOUNT_LOOKUP_SERVICE}}/parties/MSISDN/{{pathfinderMSISDN}}",
+									"host": [
+										"{{HOST_ACCOUNT_LOOKUP_SERVICE}}"
+									],
+									"path": [
+										"parties",
+										"MSISDN",
+										"{{pathfinderMSISDN}}"
+									]
+								},
+								"description": "Author: Sridevi Miriyala\n\nThe payer is requesting the information of the payee. The response shd include payee's firstname, lastname, DOB."
+							},
+							"response": []
+						},
+						{
+							"name": "Send Quote",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+										"exec": [
+											"   var uuid = require('uuid');",
+											"   var generatedUUID = uuid.v4();",
+											"   pm.environment.set('quoteId', generatedUUID);",
+											"   generatedUUID = uuid.v4();",
+											"   pm.environment.set('transactionId', generatedUUID);",
+											"",
+											"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"",
+											"//Check Data on payer side",
+											"setTimeout(function () {",
+											"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
+											"      if(response.responseSize !== 0) {",
+											"          //Checking headers",
+											"            var headers = response.json().headers;",
+											"            pm.test(\"payerfsp fspiop-source is payeefsp\", function () {",
+											"                pm.expect(headers['fspiop-source']).to.eql('payeefsp');",
+											"            });",
+											"            ",
+											"            pm.test(\"payerfsp fspiop-destination is payerfsp\", function () {",
+											"                pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
+											"            });",
+											"            ",
+											"            pm.test(\"payerfsp content-type should be application/vnd.interoperability.quotes+json;version=1.0\", function () {",
+											"                pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.quotes+json;version=1.0');",
+											"            });",
+											"            ",
+											"            pm.test(\"payerfsp accept is empty\", function () {",
+											"                pm.expect(headers['accept']).to.eql(undefined);",
+											"            });",
+											"            ",
+											"            ",
+											"            ",
+											"            //Validate protected header inside Signature",
+											"            var {signature,protectedHeader} = JSON.parse(headers['fspiop-signature'])",
+											"            var decodedProtectedHeaders = JSON.parse(atob(protectedHeader))",
+											"            console.log('decodedProtectedHeaders:',decodedProtectedHeaders)",
+											"            ",
+											"            // pm.test(\"FSPIOP-Signature signature is returned\", function () {",
+											"            //     pm.expect(signature).to.eql(pm.environment.get(\"payeefsp-signature\"));",
+											"            // });",
+											"            ",
+											"            pm.test(\"FSPIOP-Signature Protected Header alg to be RS256\", function () {",
+											"                pm.expect(decodedProtectedHeaders['alg']).to.eql('RS256');",
+											"            });",
+											"            pm.test(\"FSPIOP-Signature Protected Header FSPIOP-URI to be /quotes/\"+pm.environment.get(\"quoteId\"), function () {",
+											"                pm.expect(decodedProtectedHeaders['FSPIOP-URI']).to.eql('/quotes/'+pm.environment.get(\"quoteId\"));",
+											"            });",
+											"            ",
+											"",
+											"            pm.test(\"FSPIOP-Signature Protected Header FSPIOP-HTTP-Method to be PUT\", function () {",
+											"                pm.expect(decodedProtectedHeaders['FSPIOP-HTTP-Method']).to.eql('PUT');",
+											"            });",
+											"            pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Source to be mojaloop-sdk\", function () {",
+											"                pm.expect(decodedProtectedHeaders['FSPIOP-Source']).to.eql('payeefsp');",
+											"            });",
+											"            pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Destination to be payerfsp\", function () {",
+											"                pm.expect(decodedProtectedHeaders['FSPIOP-Destination']).to.eql('payerfsp');",
+											"            });",
+											"            pm.test(\"FSPIOP-Signature Protected Header Date is present\", function () {",
+											"                pm.expect(decodedProtectedHeaders['Date']).to.not.eql(undefined);",
+											"            });",
+											"           ",
+											"            pm.test(\"payerfsp FSPIOP-URI to be /quotes/\"+pm.environment.get(\"quoteId\"), function () {",
+											"                pm.expect(headers['fspiop-uri']).to.eql('/quotes/'+pm.environment.get(\"quoteId\"));",
+											"            });",
+											"            ",
+											"            pm.test(\"payerfsp fspiop-http-method is PUT\", function () {",
+											"                pm.expect(headers['fspiop-http-method']).to.eql('PUT');",
+											"            });",
+											"            ",
+											"            var jsonData = response.json().data;",
+											"          ",
+											"            pm.test(\"Response ilpPacket is not undefined\", function () {",
+											"                pm.expect(jsonData.ilpPacket).not.equal(undefined);",
+											"                pm.environment.set(\"ilpPacket\", jsonData.ilpPacket);",
+											"            });",
+											"       ",
+											"           pm.test(\"Response condition is not undefined\", function () {",
+											"               pm.expect(jsonData.condition).not.equal(undefined);",
+											"               pm.environment.set(\"condition\", jsonData.condition);",
+											"           });",
+											"      } else {",
+											"          pm.test(\"Quote FAILED\", function () {",
+											"            throw new Error('Did not receive response');",
+											"           });",
+											"",
+											"      }",
+											"       ",
+											"   });",
+											"}, 1000)",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{TESTFSP1_BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.quotes+json"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.quotes+json;version=1.0"
+									},
+									{
+										"key": "Date",
+										"value": "{{dateHeader}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "payerfsp"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"value": "payeefsp"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"payerfsp\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"payeefsp\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"60\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+								},
+								"url": {
+									"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+									"host": [
+										"{{HOST_QUOTING_SERVICE}}"
+									],
+									"path": [
+										"quotes"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Send Transfer",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "900142b0-e4d7-43a4-a751-38202b600661",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"//Check the request that Switch forwards to payeefsp",
+											"setTimeout(function () {",
+											"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payeefsp/requests/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+											"          if(response.responseSize !== 0) {",
+											"              ",
+											"              //Check the Headers",
+											"              var headers = response.json().headers;",
+											"              ",
+											"                pm.test(\"payeefsp fspiop-source is payerfsp\", function () {",
+											"                    pm.expect(headers['fspiop-source']).to.eql('payerfsp');",
+											"                });",
+											"                ",
+											"                pm.test(\"payeefsp fspiop-destination is payeefsp\", function () {",
+											"                    pm.expect(headers['fspiop-destination']).to.eql('payeefsp');",
+											"                });",
+											"                ",
+											"                pm.test(\"payeefsp content-typeis same as sent in the request\", function () {",
+											"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+											"                });",
+											"                ",
+											"                pm.test(\"payeefsp accept is same as sent in the request\", function () {",
+											"                    pm.expect(headers['accept']).to.eql('application/vnd.interoperability.transfers+json;version=1');",
+											"                });",
+											"                ",
+											"                pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
+											"                    pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
+											"                });",
+											"                ",
+											"                pm.test(\"payeefsp fspiop-http-method is POST\", function () {",
+											"                    pm.expect(headers['fspiop-http-method']).to.eql('POST');",
+											"                });",
+											"                ",
+											"                pm.test(\"payeefsp fspiop-uri is /transfers\", function () {",
+											"                    pm.expect(headers['fspiop-uri']).to.eql('/transfers');",
+											"                });",
+											"                ",
+											"                ",
+											"                //Check the data",
+											"                var jsonData = response.json().data;",
+											"                pm.test(\"payeefsp data should have the same transferId as request\", function () {",
+											"                   pm.expect(jsonData.transferId).to.eql(pm.environment.get(\"transfer_ID\"));",
+											"                });",
+											"                pm.test(\"payeefsp data should have the same payerfspId as request\", function () {",
+											"                   pm.expect(jsonData.payerFsp).to.eql(pm.environment.get(\"payerfsp\"));",
+											"                });",
+											"                pm.test(\"payeefsp data should have the same payeefspId as request\", function () {",
+											"                   pm.expect(jsonData.payeeFsp).to.eql(pm.environment.get(\"payeefsp\"));",
+											"                });",
+											"                pm.test(\"payeefsp data should have the same amount as request\", function () {",
+											"                   pm.expect(jsonData.amount.amount).to.eql('1');",
+											"                });",
+											"                pm.test(\"payeefsp data should have the same currency as request\", function () {",
+											"                   pm.expect(jsonData.amount.currency).to.eql(pm.environment.get(\"currency\"));",
+											"                });",
+											"                pm.test(\"payeefsp data should have the same expiration as request\", function () {",
+											"                   pm.expect(jsonData.expiration).to.eql(pm.environment.get(\"transferExpiration\"));",
+											"                });",
+											"                pm.test(\"payeefsp data should have the same ilpPacket as request\", function () {",
+											"                   pm.expect(jsonData.ilpPacket).to.eql(pm.environment.get(\"ilpPacket\"));",
+											"                });",
+											"                pm.test(\"payeefsp data should have the same condition as request\", function () {",
+											"                   pm.expect(jsonData.condition).to.eql(pm.environment.get(\"condition\"));",
+											"                });",
+											"                ",
+											"          } else {",
+											"              pm.test(\"Transfer FAILED\", function () {",
+											"                throw new Error('Did not receive response');",
+											"              });",
+											"",
+											"          }",
+											"   });",
+											"}, 1100)",
+											"",
+											"//Check the callback response that Switch forwards to payerfsp",
+											"setTimeout(function () {",
+											"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+											"          if(response.responseSize !== 0) {",
+											"            //Checking headers",
+											"            var headers = response.json().headers;",
+											"            pm.test(\"payerfsp fspiop-source is payeefsp\", function () {",
+											"                pm.expect(headers['fspiop-source']).to.eql('payeefsp');",
+											"            });",
+											"            ",
+											"            pm.test(\"payerfsp fspiop-destination is payerfsp\", function () {",
+											"                pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
+											"            });",
+											"            ",
+											"            pm.test(\"payerfsp content-type should be application/vnd.interoperability.transfers+json;version=1.0\", function () {",
+											"                pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+											"            });",
+											"            ",
+											"            pm.test(\"payerfsp accept is empty\", function () {",
+											"                pm.expect(headers['accept']).to.eql(undefined);",
+											"            });",
+											"            ",
+											"            // pm.test(\"fspiop-signature is returned\", function () {",
+											"            //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"payeefsp_fspiop_signature\"));",
+											"            // });",
+											"           ",
+											"            ",
+											"            pm.test(\"payerfsp fspiop-uri includes transfers\", function () {",
+											"                pm.expect(headers['fspiop-uri']).to.include('/transfers');",
+											"            });",
+											"            ",
+											"            pm.test(\"payerfsp fspiop-http-method is PUT\", function () {",
+											"                pm.expect(headers['fspiop-http-method']).to.eql('PUT');",
+											"            });",
+											"            ",
+											"            var jsonData = response.json().data;",
+											"            pm.test(\"Response data does not have transferId\", function () {",
+											"               pm.expect(jsonData.transferId).to.eql(undefined);",
+											"            });",
+											"            pm.test(\"Response status is COMMITTED\", function () {",
+											"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+											"            });",
+											"          } else {",
+											"              pm.test(\"Transfer FAILED\", function () {",
+											"                throw new Error('Did not receive response');",
+											"              });",
+											"",
+											"          }",
+											"   });",
+											"}, 1300)",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "20820c95-0a24-4906-a6ba-708d6ecf4a61",
+										"exec": [
+											"var uuid = require('uuid');",
+											"var generatedUUID = uuid.v4();",
+											"pm.environment.set('transfer_ID', generatedUUID);",
+											"",
+											"pm.variables.set('transferDate', (new Date()).toUTCString());",
+											"",
+											"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 600000))"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.transfers+json;version=1.0"
+									},
+									{
+										"key": "Date",
+										"value": "{{transferDate}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"value": "{{payeefsp}}"
+									},
+									{
+										"key": "FSPIOP-Signature",
+										"value": "{{fspiop-signature}}",
+										"type": "text"
+									},
+									{
+										"key": "FSPIOP-URI",
+										"value": "/transfers",
+										"type": "text"
+									},
+									{
+										"key": "FSPIOP-HTTP-Method",
+										"value": "POST",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"{{payeefsp}}\",\n  \"amount\": {\n    \"amount\": \"1\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
+								},
+								"url": {
+									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+									"host": [
+										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+									],
+									"path": [
+										"transfers"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				}
+			],
+			"description": "Author: Sridevi Miriyala",
+			"event": [
+				{
 					"listen": "prerequest",
 					"script": {
-						"id": "e3f505ea-4c76-4c5c-944c-c9188b39b699",
+						"id": "bd53c7ee-b55d-4d1a-a178-3c09e68e8901",
+						"type": "text/javascript",
 						"exec": [
-							"pm.environment.set('fullName', 'Siabelo Maroka');",
-							"pm.environment.set('firstName', 'Siabelo');",
-							"pm.environment.set('lastName', 'Maroka');",
-							"pm.environment.set('dob', '3/3/1973');",
 							""
-						],
-						"type": "text/javascript"
-					}
-				},
-					{
-						"listen": "test",
-						"script": {
-							"id": "a34ed0a6-ec7f-4147-8103-ec17cefcb9e7",
-							"exec": [
-								"pm.test(\"Status code is 202\", function () {",
-								"    pm.response.to.have.status(202);",
-								"});"
-							],
-							"type": "text/javascript"
-						}
-					}
-				],
-				"request": {
-					"method": "POST",
-					"header": [{
-						"key": "Content-Type",
-						"value": "application/json"
-					}],
-					"body": {
-						"mode": "raw",
-						"raw": "{\n    \"party\": {\n        \"partyIdInfo\": {\n            \"partyIdType\": \"MSISDN\",\n            \"partyIdentifier\": \"{{pathfinderMSISDN}}\",\n            \"fspId\": \"{{payeefsp}}\"\n        },\n        \"name\": \"{{fullName}}\",\n        \"personalInfo\": {\n            \"complexName\": {\n                \"firstName\": \"{{firstName}}\",\n                \"lastName\": \"{{lastName}}\"\n            },\n            \"dateOfBirth\": \"{{dob}}\"\n        }\n    }\n}"
-					},
-					"url": {
-						"raw": "{{HOST_SIMULATOR}}/payeefsp/parties/MSISDN/{{pathfinderMSISDN}}",
-						"host": [
-							"{{HOST_SIMULATOR}}"
-						],
-						"path": [
-							"payeefsp",
-							"parties",
-							"MSISDN",
-							"{{pathfinderMSISDN}}"
 						]
 					}
 				},
-				"response": []
-			},
 				{
-					"name": "Get Party Receiver",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "decab794-66d7-4b03-b6da-4191441206a8",
-							"exec": [
-								"pm.test(\"Status code is 202\", function () {",
-								"    pm.response.to.have.status(202);",
-								"});",
-								"",
-								"//Check data on payee side",
-								"setTimeout(function () {",
-								"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payeefsp/requests/\"+pm.variables.get(\"pathfinderMSISDN\"), function (err, response) {",
-								"       ",
-								"       if(response.responseSize !== 0) { ",
-								"       //Checking headers",
-								"        var headers = response.json().headers;",
-								"        pm.test(\"payeefsp fspiop-source is payerfsp\", function () {",
-								"            pm.expect(headers['fspiop-source']).to.eql('payerfsp');",
-								"        });",
-								"        ",
-								"        pm.test(\"payeefsp fspiop-destination is payeefsp\", function () {",
-								"            pm.expect(headers['fspiop-destination']).to.eql('payeefsp');",
-								"        });",
-								"        ",
-								"        pm.test(\"payeefsp content-type should be application/vnd.interoperability.parties+json;version=1.0\", function () {",
-								"            pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.parties+json;version=1.0');",
-								"        });",
-								"        ",
-								"        //pm.test(\"payeefsp accept should be application/vnd.interoperability.parties+json;version=1\", function () {",
-								"        //    pm.expect(headers['accept']).to.eql('should be application/vnd.interoperability.parties+json;version=1');",
-								"        //});",
-								"        ",
-								"        ",
-								"        ",
-								"        //Validate protected header inside Signature",
-								"        var {signature,protectedHeader} = JSON.parse(headers['fspiop-signature'])",
-								"        var decodedProtectedHeaders = JSON.parse(atob(protectedHeader))",
-								"        console.log('decodedProtectedHeaders:',decodedProtectedHeaders)",
-								"        ",
-								"        // pm.test(\"FSPIOP-Signature signature is returned\", function () {",
-								"        //     pm.expect(signature).to.eql(pm.environment.get(\"payeefsp-signature\"));",
-								"        // });",
-								"        ",
-								"        pm.test(\"FSPIOP-Signature Protected Header alg to be RS256\", function () {",
-								"            pm.expect(decodedProtectedHeaders['alg']).to.eql('RS256');",
-								"        });",
-								"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-URI to be /parties\", function () {",
-								"            pm.expect(decodedProtectedHeaders['FSPIOP-URI']).to.eql('/parties');",
-								"        });",
-								"        ",
-								"",
-								"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-HTTP-Method to be GET\", function () {",
-								"            pm.expect(decodedProtectedHeaders['FSPIOP-HTTP-Method']).to.eql('GET');",
-								"        });",
-								"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Source to be Payerfsp\", function () {",
-								"            pm.expect(decodedProtectedHeaders['FSPIOP-Source']).to.eql('payerfsp');",
-								"        });",
-								"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Destination to be payeefsp\", function () {",
-								"            pm.expect(decodedProtectedHeaders['FSPIOP-Destination']).to.eql('payeefsp');",
-								"        });",
-								"        pm.test(\"FSPIOP-Signature Protected Header Date is present\", function () {",
-								"            pm.expect(decodedProtectedHeaders['Date']).to.not.eql(undefined);",
-								"        });",
-								"       ",
-								"        pm.test(\"payeefsp FSPIOP-URI to be /parties\", function () {",
-								"            pm.expect(headers['fspiop-uri']).to.eql('/parties');",
-								"        });",
-								"        ",
-								"        pm.test(\"payeefsp fspiop-http-method is GET\", function () {",
-								"            pm.expect(headers['fspiop-http-method']).to.eql('GET');",
-								"        });",
-								"        ",
-								"        ",
-								"        ",
-								"       } else {",
-								"           pm.test(\"Parties FAILED - payeeFSP\", function () {",
-								"            throw new Error('Did not receive response');",
-								"           });",
-								"           ",
-								"       }",
-								"      ",
-								"    });",
-								"}, 4000)",
-								"",
-								"//Check data on payer side",
-								"setTimeout(function () {",
-								"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.variables.get(\"pathfinderMSISDN\"), function (err, response) {",
-								"       ",
-								"       if(response.responseSize !== 0) { ",
-								"       //Checking headers",
-								"        var headers = response.json().headers;",
-								"        pm.test(\"payerfsp fspiop-source is payeefsp\", function () {",
-								"            pm.expect(headers['fspiop-source']).to.eql('payeefsp');",
-								"        });",
-								"        ",
-								"        pm.test(\"payerfsp fspiop-destination is payerfsp\", function () {",
-								"            pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
-								"        });",
-								"        ",
-								"        pm.test(\"payerfsp content-type should be application/vnd.interoperability.parties+json;version=1.0\", function () {",
-								"            pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.parties+json;version=1.0');",
-								"        });",
-								"        ",
-								"        pm.test(\"payerfsp accept is empty\", function () {",
-								"            pm.expect(headers['accept']).to.eql(undefined);",
-								"        });",
-								"        ",
-								"        ",
-								"        ",
-								"        //Validate protected header inside Signature",
-								"        var {signature,protectedHeader} = JSON.parse(headers['fspiop-signature'])",
-								"        var decodedProtectedHeaders = JSON.parse(atob(protectedHeader))",
-								"        console.log('decodedProtectedHeaders:',decodedProtectedHeaders)",
-								"        ",
-								"        // pm.test(\"FSPIOP-Signature signature is returned\", function () {",
-								"        //     pm.expect(signature).to.eql(pm.environment.get(\"payeefsp-signature\"));",
-								"        // });",
-								"        ",
-								"        pm.test(\"FSPIOP-Signature Protected Header alg to be RS256\", function () {",
-								"            pm.expect(decodedProtectedHeaders['alg']).to.eql('RS256');",
-								"        });",
-								"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-URI to be /parties/MSISDN/\"+pm.environment.get(\"pathfinderMSISDN\"), function () {",
-								"            pm.expect(decodedProtectedHeaders['FSPIOP-URI']).to.eql('/parties/MSISDN/'+pm.environment.get(\"pathfinderMSISDN\"));",
-								"        });",
-								"        ",
-								"",
-								"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-HTTP-Method to be PUT\", function () {",
-								"            pm.expect(decodedProtectedHeaders['FSPIOP-HTTP-Method']).to.eql('PUT');",
-								"        });",
-								"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Source to be mojaloop-sdk\", function () {",
-								"            pm.expect(decodedProtectedHeaders['FSPIOP-Source']).to.eql('payeefsp');",
-								"        });",
-								"        pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Destination to be payerfsp\", function () {",
-								"            pm.expect(decodedProtectedHeaders['FSPIOP-Destination']).to.eql('payerfsp');",
-								"        });",
-								"        pm.test(\"FSPIOP-Signature Protected Header Date is present\", function () {",
-								"            pm.expect(decodedProtectedHeaders['Date']).to.not.eql(undefined);",
-								"        });",
-								"       ",
-								"        //pm.test(\"payerfsp FSPIOP-URI to be /parties/MSISDN/\"+pm.environment.get(\"pathfinderMSISDN\"), function () {",
-								"        //    pm.expect(headers['fspiop-uri']).to.eql('/parties/MSISDN/'+pm.environment.get(\"pathfinderMSISDN\"));",
-								"        //});",
-								"        ",
-								"        pm.test(\"payerfsp fspiop-http-method is PUT\", function () {",
-								"            pm.expect(headers['fspiop-http-method']).to.eql('PUT');",
-								"        });",
-								"        ",
-								"        //Checking data",
-								"        var jsonData = response.json().data;",
-								"       pm.test(\"Expected receiver first name is: \"+pm.variables.get(\"expectedFirstName\"), function () {",
-								"           pm.expect(jsonData.party.personalInfo.complexName.firstName).to.eql(pm.variables.get(\"expectedFirstName\"));",
-								"        });",
-								"        pm.test(\"Expected receiver last name is: \"+pm.variables.get(\"expectedLastName\"), function () {",
-								"          pm.expect(jsonData.party.personalInfo.complexName.lastName).to.eql(pm.variables.get(\"expectedLastName\"));",
-								"        });",
-								"        pm.test(\"Expected receiver DOB: \"+pm.variables.get(\"expectedDOB\"), function () {",
-								"          pm.expect(jsonData.party.personalInfo.dateOfBirth).to.eql(pm.variables.get(\"expectedDOB\"));",
-								"        });  ",
-								"        ",
-								"       } else {",
-								"           pm.test(\"Parties FAILED - payerFSP\", function () {",
-								"            throw new Error('Did not receive response');",
-								"           });",
-								"           ",
-								"       }",
-								"      ",
-								"    });",
-								"}, 4000)",
-								"",
-								""
-							],
-							"type": "text/javascript"
-						}
-					},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "c0e9b1b6-9f17-42f4-b7aa-9317535a62b7",
-								"exec": [
-									"pm.variables.set('expectedFullName', 'Siabelo Maroka');",
-									"pm.variables.set('expectedFirstName', 'Siabelo');",
-									"pm.variables.set('expectedLastName', 'Maroka');",
-									"pm.variables.set('expectedDOB', '3/3/1973');",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [{
-							"key": "Accept",
-							"value": "application/vnd.interoperability.parties+json;version=1",
-							"type": "text"
-						},
-							{
-								"key": "Content-Type",
-								"value": "application/vnd.interoperability.parties+json;version=1.0",
-								"type": "text"
-							},
-							{
-								"key": "FSPIOP-Source",
-								"value": "{{payerfsp}}",
-								"type": "text"
-							},
-							{
-								"key": "FSPIOP-Destination",
-								"value": "{{payeefsp}}",
-								"type": "text"
-							},
-							{
-								"key": "Date",
-								"value": "{{dateHeader}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{HOST_ACCOUNT_LOOKUP_SERVICE}}/parties/MSISDN/{{pathfinderMSISDN}}",
-							"host": [
-								"{{HOST_ACCOUNT_LOOKUP_SERVICE}}"
-							],
-							"path": [
-								"parties",
-								"MSISDN",
-								"{{pathfinderMSISDN}}"
-							]
-						},
-						"description": "Author: Sridevi Miriyala\n\nThe payer is requesting the information of the payee. The response shd include payee's firstname, lastname, DOB."
-					},
-					"response": []
-				},
+					"listen": "test",
+					"script": {
+						"id": "c2b5e1bd-f23e-4874-98a7-fc62bcd9d331",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "block_transfer ( p>ndc )",
+			"item": [
 				{
-					"name": "Send Quote",
-					"event": [{
-						"listen": "prerequest",
-						"script": {
-							"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-							"exec": [
-								"   var uuid = require('uuid');",
-								"   var generatedUUID = uuid.v4();",
-								"   pm.environment.set('quoteId', generatedUUID);",
-								"   generatedUUID = uuid.v4();",
-								"   pm.environment.set('transactionId', generatedUUID);",
-								"",
-								"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-								""
-							],
-							"type": "text/javascript"
-						}
-					},
+					"name": "GET limits-payerfsp",
+					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
+								"id": "a75db36e-2d2f-432c-81a6-77f912c41aa9",
 								"exec": [
-									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
 									"});",
 									"",
-									"",
-									"//Check Data on payer side",
-									"setTimeout(function () {",
-									"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-									"      if(response.responseSize !== 0) {",
-									"          //Checking headers",
-									"            var headers = response.json().headers;",
-									"            pm.test(\"payerfsp fspiop-source is payeefsp\", function () {",
-									"                pm.expect(headers['fspiop-source']).to.eql('payeefsp');",
-									"            });",
-									"            ",
-									"            pm.test(\"payerfsp fspiop-destination is payerfsp\", function () {",
-									"                pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
-									"            });",
-									"            ",
-									"            pm.test(\"payerfsp content-type should be application/vnd.interoperability.quotes+json;version=1.0\", function () {",
-									"                pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.quotes+json;version=1.0');",
-									"            });",
-									"            ",
-									"            pm.test(\"payerfsp accept is empty\", function () {",
-									"                pm.expect(headers['accept']).to.eql(undefined);",
-									"            });",
-									"            ",
-									"            ",
-									"            ",
-									"            //Validate protected header inside Signature",
-									"            var {signature,protectedHeader} = JSON.parse(headers['fspiop-signature'])",
-									"            var decodedProtectedHeaders = JSON.parse(atob(protectedHeader))",
-									"            console.log('decodedProtectedHeaders:',decodedProtectedHeaders)",
-									"            ",
-									"            // pm.test(\"FSPIOP-Signature signature is returned\", function () {",
-									"            //     pm.expect(signature).to.eql(pm.environment.get(\"payeefsp-signature\"));",
-									"            // });",
-									"            ",
-									"            pm.test(\"FSPIOP-Signature Protected Header alg to be RS256\", function () {",
-									"                pm.expect(decodedProtectedHeaders['alg']).to.eql('RS256');",
-									"            });",
-									"            pm.test(\"FSPIOP-Signature Protected Header FSPIOP-URI to be /quotes/\"+pm.environment.get(\"quoteId\"), function () {",
-									"                pm.expect(decodedProtectedHeaders['FSPIOP-URI']).to.eql('/quotes/'+pm.environment.get(\"quoteId\"));",
-									"            });",
-									"            ",
-									"",
-									"            pm.test(\"FSPIOP-Signature Protected Header FSPIOP-HTTP-Method to be PUT\", function () {",
-									"                pm.expect(decodedProtectedHeaders['FSPIOP-HTTP-Method']).to.eql('PUT');",
-									"            });",
-									"            pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Source to be mojaloop-sdk\", function () {",
-									"                pm.expect(decodedProtectedHeaders['FSPIOP-Source']).to.eql('payeefsp');",
-									"            });",
-									"            pm.test(\"FSPIOP-Signature Protected Header FSPIOP-Destination to be payerfsp\", function () {",
-									"                pm.expect(decodedProtectedHeaders['FSPIOP-Destination']).to.eql('payerfsp');",
-									"            });",
-									"            pm.test(\"FSPIOP-Signature Protected Header Date is present\", function () {",
-									"                pm.expect(decodedProtectedHeaders['Date']).to.not.eql(undefined);",
-									"            });",
-									"           ",
-									"            pm.test(\"payerfsp FSPIOP-URI to be /quotes/\"+pm.environment.get(\"quoteId\"), function () {",
-									"                pm.expect(headers['fspiop-uri']).to.eql('/quotes/'+pm.environment.get(\"quoteId\"));",
-									"            });",
-									"            ",
-									"            pm.test(\"payerfsp fspiop-http-method is PUT\", function () {",
-									"                pm.expect(headers['fspiop-http-method']).to.eql('PUT');",
-									"            });",
-									"            ",
-									"            var jsonData = response.json().data;",
-									"          ",
-									"            pm.test(\"Response ilpPacket is not undefined\", function () {",
-									"                pm.expect(jsonData.ilpPacket).not.equal(undefined);",
-									"                pm.environment.set(\"ilpPacket\", jsonData.ilpPacket);",
-									"            });",
-									"       ",
-									"           pm.test(\"Response condition is not undefined\", function () {",
-									"               pm.expect(jsonData.condition).not.equal(undefined);",
-									"               pm.environment.set(\"condition\", jsonData.condition);",
-									"           });",
-									"      } else {",
-									"          pm.test(\"Quote FAILED\", function () {",
-									"            throw new Error('Did not receive response');",
-									"           });",
-									"",
-									"      }",
-									"       ",
-									"   });",
-									"}, 1000)",
-									"",
-									"",
-									""
+									"var jsonData = pm.response.json();",
+									"var payerNDC = jsonData[0].limit.value",
+									"pm.environment.set(\"payerNDC\",payerNDC)"
 								],
 								"type": "text/javascript"
 							}
 						}
 					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [{
-								"key": "token",
-								"value": "{{TESTFSP1_BEARER_TOKEN}}",
-								"type": "string"
-							}]
-						},
-						"method": "POST",
-						"header": [{
-							"key": "Accept",
-							"value": "application/vnd.interoperability.quotes+json"
-						},
-							{
-								"key": "Content-Type",
-								"value": "application/vnd.interoperability.quotes+json;version=1.0"
-							},
-							{
-								"key": "Date",
-								"value": "{{dateHeader}}"
-							},
-							{
-								"key": "FSPIOP-Source",
-								"value": "payerfsp"
-							},
-							{
-								"key": "FSPIOP-Destination",
-								"value": "payeefsp"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"payerfsp\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"payeefsp\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"60\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
-						},
-						"url": {
-							"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
-							"host": [
-								"{{HOST_QUOTING_SERVICE}}"
-							],
-							"path": [
-								"quotes"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Send Transfer",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "900142b0-e4d7-43a4-a751-38202b600661",
-							"exec": [
-								"pm.test(\"Status code is 202\", function () {",
-								"    pm.response.to.have.status(202);",
-								"});",
-								"",
-								"//Check the request that Switch forwards to payeefsp",
-								"setTimeout(function () {",
-								"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payeefsp/requests/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-								"          if(response.responseSize !== 0) {",
-								"              ",
-								"              //Check the Headers",
-								"              var headers = response.json().headers;",
-								"              ",
-								"                pm.test(\"payeefsp fspiop-source is payerfsp\", function () {",
-								"                    pm.expect(headers['fspiop-source']).to.eql('payerfsp');",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp fspiop-destination is payeefsp\", function () {",
-								"                    pm.expect(headers['fspiop-destination']).to.eql('payeefsp');",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp content-typeis same as sent in the request\", function () {",
-								"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp accept is same as sent in the request\", function () {",
-								"                    pm.expect(headers['accept']).to.eql('application/vnd.interoperability.transfers+json;version=1');",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
-								"                    pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp fspiop-http-method is POST\", function () {",
-								"                    pm.expect(headers['fspiop-http-method']).to.eql('POST');",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp fspiop-uri is /transfers\", function () {",
-								"                    pm.expect(headers['fspiop-uri']).to.eql('/transfers');",
-								"                });",
-								"                ",
-								"                ",
-								"                //Check the data",
-								"                var jsonData = response.json().data;",
-								"                pm.test(\"payeefsp data should have the same transferId as request\", function () {",
-								"                   pm.expect(jsonData.transferId).to.eql(pm.environment.get(\"transfer_ID\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same payerfspId as request\", function () {",
-								"                   pm.expect(jsonData.payerFsp).to.eql(pm.environment.get(\"payerfsp\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same payeefspId as request\", function () {",
-								"                   pm.expect(jsonData.payeeFsp).to.eql(pm.environment.get(\"payeefsp\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same amount as request\", function () {",
-								"                   pm.expect(jsonData.amount.amount).to.eql('1');",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same currency as request\", function () {",
-								"                   pm.expect(jsonData.amount.currency).to.eql(pm.environment.get(\"currency\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same expiration as request\", function () {",
-								"                   pm.expect(jsonData.expiration).to.eql(pm.environment.get(\"transferExpiration\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same ilpPacket as request\", function () {",
-								"                   pm.expect(jsonData.ilpPacket).to.eql(pm.environment.get(\"ilpPacket\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same condition as request\", function () {",
-								"                   pm.expect(jsonData.condition).to.eql(pm.environment.get(\"condition\"));",
-								"                });",
-								"                ",
-								"          } else {",
-								"              pm.test(\"Transfer FAILED\", function () {",
-								"                throw new Error('Did not receive response');",
-								"              });",
-								"",
-								"          }",
-								"   });",
-								"}, 1100)",
-								"",
-								"//Check the callback response that Switch forwards to payerfsp",
-								"setTimeout(function () {",
-								"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-								"          if(response.responseSize !== 0) {",
-								"            //Checking headers",
-								"            var headers = response.json().headers;",
-								"            pm.test(\"payerfsp fspiop-source is payeefsp\", function () {",
-								"                pm.expect(headers['fspiop-source']).to.eql('payeefsp');",
-								"            });",
-								"            ",
-								"            pm.test(\"payerfsp fspiop-destination is payerfsp\", function () {",
-								"                pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
-								"            });",
-								"            ",
-								"            pm.test(\"payerfsp content-type should be application/vnd.interoperability.transfers+json;version=1.0\", function () {",
-								"                pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-								"            });",
-								"            ",
-								"            pm.test(\"payerfsp accept is empty\", function () {",
-								"                pm.expect(headers['accept']).to.eql(undefined);",
-								"            });",
-								"            ",
-								"            // pm.test(\"fspiop-signature is returned\", function () {",
-								"            //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"payeefsp_fspiop_signature\"));",
-								"            // });",
-								"           ",
-								"            ",
-								"            pm.test(\"payerfsp fspiop-uri includes transfers\", function () {",
-								"                pm.expect(headers['fspiop-uri']).to.include('/transfers');",
-								"            });",
-								"            ",
-								"            pm.test(\"payerfsp fspiop-http-method is PUT\", function () {",
-								"                pm.expect(headers['fspiop-http-method']).to.eql('PUT');",
-								"            });",
-								"            ",
-								"            var jsonData = response.json().data;",
-								"            pm.test(\"Response data does not have transferId\", function () {",
-								"               pm.expect(jsonData.transferId).to.eql(undefined);",
-								"            });",
-								"            pm.test(\"Response status is COMMITTED\", function () {",
-								"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-								"            });",
-								"          } else {",
-								"              pm.test(\"Transfer FAILED\", function () {",
-								"                throw new Error('Did not receive response');",
-								"              });",
-								"",
-								"          }",
-								"   });",
-								"}, 1300)",
-								"",
-								"",
-								""
-							],
-							"type": "text/javascript"
-						}
-					},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "20820c95-0a24-4906-a6ba-708d6ecf4a61",
-								"exec": [
-									"var uuid = require('uuid');",
-									"var generatedUUID = uuid.v4();",
-									"pm.environment.set('transfer_ID', generatedUUID);",
-									"",
-									"pm.variables.set('transferDate', (new Date()).toUTCString());",
-									"",
-									"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 600000))"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [{
-							"key": "Accept",
-							"value": "application/vnd.interoperability.transfers+json;version=1"
-						},
-							{
-								"key": "Content-Type",
-								"value": "application/vnd.interoperability.transfers+json;version=1.0"
-							},
-							{
-								"key": "Date",
-								"value": "{{transferDate}}"
-							},
-							{
-								"key": "FSPIOP-Source",
-								"value": "{{payerfsp}}"
-							},
-							{
-								"key": "FSPIOP-Destination",
-								"value": "{{payeefsp}}"
-							},
-							{
-								"key": "FSPIOP-Signature",
-								"value": "{{fspiop-signature}}",
-								"type": "text"
-							},
-							{
-								"key": "FSPIOP-URI",
-								"value": "/transfers",
-								"type": "text"
-							},
-							{
-								"key": "FSPIOP-HTTP-Method",
-								"value": "POST",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"{{payeefsp}}\",\n  \"amount\": {\n    \"amount\": \"1\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
-						},
-						"url": {
-							"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-							"host": [
-								"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-							],
-							"path": [
-								"transfers"
-							]
-						}
-					},
-					"response": []
-				}
-			],
-			"_postman_isSubFolder": true
-		}],
-		"description": "Author: Sridevi Miriyala",
-		"event": [{
-			"listen": "prerequest",
-			"script": {
-				"id": "bd53c7ee-b55d-4d1a-a178-3c09e68e8901",
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		},
-			{
-				"listen": "test",
-				"script": {
-					"id": "c2b5e1bd-f23e-4874-98a7-fc62bcd9d331",
-					"type": "text/javascript",
-					"exec": [
-						""
-					]
-				}
-			}
-		]
-	},
-		{
-			"name": "block_transfer ( p>ndc )",
-			"item": [{
-				"name": "GET limits-payerfsp",
-				"event": [{
-					"listen": "test",
-					"script": {
-						"id": "a75db36e-2d2f-432c-81a6-77f912c41aa9",
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"var jsonData = pm.response.json();",
-							"var payerNDC = jsonData[0].limit.value",
-							"pm.environment.set(\"payerNDC\",payerNDC)"
-						],
-						"type": "text/javascript"
-					}
-				}],
-				"request": {
-					"method": "GET",
-					"header": [],
-					"body": {
-						"mode": "raw",
-						"raw": ""
-					},
-					"url": {
-						"raw": "{{HOST_CENTRAL_LEDGER}}/participants/payerfsp/limits",
-						"host": [
-							"{{HOST_CENTRAL_LEDGER}}"
-						],
-						"path": [
-							"participants",
-							"payerfsp",
-							"limits"
-						]
-					},
-					"description": "review the payerfsp limits/NDC"
-				},
-				"response": []
-			},
-				{
-					"name": "GET limits -payeefsp",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "84ca3f51-0bdb-4905-86d9-a6179a084f88",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});",
-								"",
-								"var jsonData = pm.response.json();",
-								"var payeeNDC = jsonData[0].limit.value",
-								"pm.environment.set('payeeNDC',payeeNDC)"
-							],
-							"type": "text/javascript"
-						}
-					}],
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
+						"url": {
+							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/payerfsp/limits",
+							"host": [
+								"{{HOST_CENTRAL_LEDGER}}"
+							],
+							"path": [
+								"participants",
+								"payerfsp",
+								"limits"
+							]
 						},
+						"description": "review the payerfsp limits/NDC"
+					},
+					"response": []
+				},
+				{
+					"name": "GET limits -payeefsp",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "84ca3f51-0bdb-4905-86d9-a6179a084f88",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"var payeeNDC = jsonData[0].limit.value",
+									"pm.environment.set('payeeNDC',payeeNDC)"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
 						"url": {
 							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/{{payeefsp}}/limits",
 							"host": [
@@ -790,38 +799,36 @@
 				},
 				{
 					"name": "Get payerfsp position before TheTransfer",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "f2c9a7dc-8b97-4b80-ad48-3b0e722f87d6",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});",
-								"",
-								"var jsonData = pm.response.json();",
-								"var result;",
-								"",
-								"jsonData.forEach( entry => {(entry.currency === pm.environment.get(\"currency\")) ? result = entry.value: result =",
-								" undefined})",
-								"",
-								"pm.test(\"Atleast one account position should be returned\", function () {",
-								"    pm.environment.set(\"payerfspPositionBeforeTransfer\", result);",
-								"    pm.expect(jsonData).to.be.not.empty;",
-								"});",
-								"",
-								""
-							],
-							"type": "text/javascript"
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f2c9a7dc-8b97-4b80-ad48-3b0e722f87d6",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"var result;",
+									"",
+									"jsonData.forEach( entry => {(entry.currency === pm.environment.get(\"currency\")) ? result = entry.value: result =",
+									" undefined})",
+									"",
+									"pm.test(\"Atleast one account position should be returned\", function () {",
+									"    pm.environment.set(\"payerfspPositionBeforeTransfer\", result);",
+									"    pm.expect(jsonData).to.be.not.empty;",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					}],
+					],
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/{{payerfsp}}/positions",
 							"host": [
@@ -839,38 +846,36 @@
 				},
 				{
 					"name": "Get payeefsp position before TheTransfer",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "9a9997f5-7f71-400c-8e4b-2234ad1aba3e",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});",
-								"",
-								"var jsonData = pm.response.json();",
-								"var result;",
-								"",
-								"jsonData.forEach( entry => {(entry.currency === pm.environment.get(\"currency\")) ? result = entry.value: result =",
-								" undefined})",
-								"",
-								"pm.test(\"Atleast one account position should be returned\", function () {",
-								"    pm.environment.set(\"payeefspPositionBeforeTransfer\", result);",
-								"    pm.expect(jsonData).to.be.not.empty;",
-								"});",
-								"",
-								""
-							],
-							"type": "text/javascript"
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9a9997f5-7f71-400c-8e4b-2234ad1aba3e",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"var result;",
+									"",
+									"jsonData.forEach( entry => {(entry.currency === pm.environment.get(\"currency\")) ? result = entry.value: result =",
+									" undefined})",
+									"",
+									"pm.test(\"Atleast one account position should be returned\", function () {",
+									"    pm.environment.set(\"payeefspPositionBeforeTransfer\", result);",
+									"    pm.expect(jsonData).to.be.not.empty;",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					}],
+					],
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/{{payeefsp}}/positions",
 							"host": [
@@ -888,27 +893,28 @@
 				},
 				{
 					"name": "Send Quote",
-					"event": [{
-						"listen": "prerequest",
-						"script": {
-							"id": "87b53856-d305-4f6e-8fd5-3a5243ae8e4a",
-							"exec": [
-								"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-								"   var uuid = require('uuid');",
-								"   var generatedUUID = uuid.v4();",
-								"   pm.variables.set('quoteId', generatedUUID);",
-								"}",
-								"",
-								"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-								"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-								"}",
-								"",
-								"var amount = Number(pm.variables.get(\"payerNDC\"))-Number( pm.variables.get(\"payerfspPositionBeforeTransfer\"))+100",
-								"pm.variables.set('transferAmount',amount)"
-							],
-							"type": "text/javascript"
-						}
-					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "87b53856-d305-4f6e-8fd5-3a5243ae8e4a",
+								"exec": [
+									"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+									"   var uuid = require('uuid');",
+									"   var generatedUUID = uuid.v4();",
+									"   pm.variables.set('quoteId', generatedUUID);",
+									"}",
+									"",
+									"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+									"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+									"}",
+									"",
+									"var amount = Number(pm.variables.get(\"payerNDC\"))-Number( pm.variables.get(\"payerfspPositionBeforeTransfer\"))+100",
+									"pm.variables.set('transferAmount',amount)"
+								],
+								"type": "text/javascript"
+							}
+						},
 						{
 							"listen": "test",
 							"script": {
@@ -956,10 +962,11 @@
 					],
 					"request": {
 						"method": "POST",
-						"header": [{
-							"key": "Accept",
-							"value": "application/vnd.interoperability.quotes+json;version=1"
-						},
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.interoperability.quotes+json;version=1"
+							},
 							{
 								"key": "Content-Type",
 								"value": "application/vnd.interoperability.quotes+json;version=1.0"
@@ -996,25 +1003,26 @@
 				},
 				{
 					"name": "Send Block Transfer",
-					"event": [{
-						"listen": "prerequest",
-						"script": {
-							"id": "373ce4bd-e96f-49df-a8e4-e2bd6e8490ab",
-							"exec": [
-								"",
-								"var uuid = require('uuid');",
-								"var generatedUUID = uuid.v4();",
-								"pm.environment.set('transfer_ID', generatedUUID);",
-								"pm.environment.set('transferDate', (new Date()).toUTCString());",
-								"",
-								"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 600000))",
-								"",
-								"var amount = Number(pm.environment.get(\"payerNDC\"))-Number( pm.variables.get(\"payerfspPositionBeforeTransfer\"))+100",
-								"pm.environment.set('transferAmount',amount)"
-							],
-							"type": "text/javascript"
-						}
-					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "373ce4bd-e96f-49df-a8e4-e2bd6e8490ab",
+								"exec": [
+									"",
+									"var uuid = require('uuid');",
+									"var generatedUUID = uuid.v4();",
+									"pm.environment.set('transfer_ID', generatedUUID);",
+									"pm.environment.set('transferDate', (new Date()).toUTCString());",
+									"",
+									"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 600000))",
+									"",
+									"var amount = Number(pm.environment.get(\"payerNDC\"))-Number( pm.variables.get(\"payerfspPositionBeforeTransfer\"))+100",
+									"pm.environment.set('transferAmount',amount)"
+								],
+								"type": "text/javascript"
+							}
+						},
 						{
 							"listen": "test",
 							"script": {
@@ -1107,10 +1115,11 @@
 					],
 					"request": {
 						"method": "POST",
-						"header": [{
-							"key": "Accept",
-							"value": "application/vnd.interoperability.transfers+json;version=1"
-						},
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.interoperability.transfers+json;version=1"
+							},
 							{
 								"key": "Content-Type",
 								"value": "application/vnd.interoperability.transfers+json;version=1.0"
@@ -1147,31 +1156,29 @@
 				},
 				{
 					"name": "Get payerfsp position after the transfer",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "7174c4f7-799f-4c4a-ad66-ab598ed32477",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});",
-								"",
-								"var jsonData = pm.response.json();",
-								"",
-								"pm.test(\"Position before and after the transfer should be the same\", function () {",
-								"    pm.expect(jsonData[0].value).to.eql(pm.environment.get(\"payerfspPositionBeforeTransfer\"));",
-								"});"
-							],
-							"type": "text/javascript"
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "7174c4f7-799f-4c4a-ad66-ab598ed32477",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Position before and after the transfer should be the same\", function () {",
+									"    pm.expect(jsonData[0].value).to.eql(pm.environment.get(\"payerfspPositionBeforeTransfer\"));",
+									"});"
+								],
+								"type": "text/javascript"
+							}
 						}
-					}],
+					],
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/{{payerfsp}}/positions",
 							"host": [
@@ -1188,31 +1195,29 @@
 				},
 				{
 					"name": "Get payeefsp position after the transfer",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "864dee38-3b5b-4709-9637-92931170b286",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});",
-								"",
-								"var jsonData = pm.response.json();",
-								"",
-								"pm.test(\"Position before and after the transfer should be the same\", function () {",
-								"    pm.expect(Number(jsonData[0].value)).to.eql(Number(pm.environment.get(\"payeefspPositionBeforeTransfer\")));",
-								"});"
-							],
-							"type": "text/javascript"
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "864dee38-3b5b-4709-9637-92931170b286",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Position before and after the transfer should be the same\", function () {",
+									"    pm.expect(Number(jsonData[0].value)).to.eql(Number(pm.environment.get(\"payeefspPositionBeforeTransfer\")));",
+									"});"
+								],
+								"type": "text/javascript"
+							}
 						}
-					}],
+					],
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/{{payeefsp}}/positions",
 							"host": [
@@ -1229,16 +1234,17 @@
 				}
 			],
 			"description": "Author: Sridevi Miriyala\n\nThis features testes, if a transfer is blocked when position of a participant exceeds the Net Debit Cap for the transfer amount.\n\nSTEPS:\n\nGET Limits\nGET Positions for payer and payee\nset amount=(NDC-P) + 10\nPOST Quotes - send to payee that responds COMMITTED\nPOST Transfers-Prepare\n      -Payerfsp should get error msg \"insufficient liquidity in payerfsp to perform transfer \" \nGET positions - \n  current payer position = prev position \n  current payee position = prev position \n(Failure of the transfer due to insufficient liquidity from payerfsp, results no change in positions)",
-			"event": [{
-				"listen": "prerequest",
-				"script": {
-					"id": "2f9024db-2f95-4bf6-9022-f7bd5d50afd3",
-					"type": "text/javascript",
-					"exec": [
-						""
-					]
-				}
-			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "2f9024db-2f95-4bf6-9022-f7bd5d50afd3",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
 				{
 					"listen": "test",
 					"script": {
@@ -1253,178 +1259,184 @@
 		},
 		{
 			"name": "funds_in",
-			"item": [{
-				"name": "Record Funds In - prepare",
-				"event": [{
-					"listen": "prerequest",
-					"script": {
-						"id": "a96ad88c-c5e9-4077-b060-765ccd1e86e1",
-						"exec": [
-							"var uuid = require('uuid');",
-							"var generatedUUID = uuid.v4();",
-							"pm.environment.set('fundsInPrepareTransferId', generatedUUID);",
-							"pm.environment.set('fundsInPrepareAmount', 5000);",
-							"",
-							"",
-							"const payerfspGetStatusRequest = {",
-							"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
-							"  method: 'GET',",
-							"  header: {",
-							"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-							"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-							"      \"Content-Type\": \"application/json\"",
-							"  }",
-							"};",
-							"pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
-							"    console.log(response.json())",
-							"    var jsonData = response.json()",
-							"    for(var i in jsonData) {",
-							"        if((jsonData[i].ledgerAccountType === 'SETTLEMENT') && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-							"            pm.environment.set(\"payerfspSettlementAccountId\",jsonData[i].id)",
-							"            pm.environment.set(\"payerfspSettlementAccountBalanceBeforeFundsIn\",jsonData[i].value)",
-							"        }",
-							"    }",
-							"});",
-							"",
-							"const hubGetStatusRequest = {",
-							"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
-							"  method: 'GET',",
-							"  header: {",
-							"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-							"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-							"      \"Content-Type\": \"application/json\"",
-							"  }",
-							"};",
-							"pm.sendRequest(hubGetStatusRequest, function (err, response) {",
-							"    console.log(response.json())",
-							"    var jsonData = response.json()",
-							"    for(var i in jsonData) {",
-							"        if((jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION') && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-							"            pm.environment.set(\"hubReconAccountBalanceBeforeFundsIn\",jsonData[i].value)",
-							"        }",
-							"    }",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				},
-					{
-						"listen": "test",
-						"script": {
-							"id": "96c26230-6092-4f78-882f-c5343b363fe1",
-							"exec": [
-								"pm.test(\"Status code is 202\", function () {",
-								"    pm.response.to.have.status(202);",
-								"});",
-								"",
-								"setTimeout(function () {",
-								"    const payerfspGetStatusRequest = {",
-								"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
-								"      method: 'GET',",
-								"      header: {",
-								"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-								"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-								"          \"Content-Type\": \"application/json\"",
-								"      }",
-								"    };",
-								"    pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
-								"        console.log('payerfsp accounts: ',response.json())",
-								"        var jsonData = response.json()",
-								"        var payerfspSettlementAccountBalanceAfterFundsIn",
-								"        for(var i in jsonData) {",
-								"            if(jsonData[i].ledgerAccountType === 'SETTLEMENT'  && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-								"                payerfspSettlementAccountBalanceAfterFundsIn = jsonData[i].value",
-								"            }",
-								"        }",
-								"        var payerfspExpectedBalance = -(-Number(pm.environment.get('payerfspSettlementAccountBalanceBeforeFundsIn')) + Number(pm.environment.get('fundsInPrepareAmount')))",
-								"        pm.test(\"Final Payerfsp Settlement Account Balance should be same as before FundsIn + fundsInPrepareAmount\", function () {",
-								"            pm.expect(payerfspSettlementAccountBalanceAfterFundsIn).to.eql(payerfspExpectedBalance);",
-								"          });    ",
-								"    ",
-								"    });",
-								"    ",
-								"    const hubGetStatusRequest = {",
-								"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
-								"      method: 'GET',",
-								"      header: {",
-								"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-								"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-								"          \"Content-Type\": \"application/json\"",
-								"      }",
-								"    };",
-								"    pm.sendRequest(hubGetStatusRequest, function (err, response) {",
-								"        console.log('hub accounts balance: ',response.json())",
-								"        var jsonData = response.json()",
-								"        var currentHubReconAccountBalance",
-								"        for(var i in jsonData) {",
-								"            if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION'  && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-								"                hubReconAccountBalanceAfterFundsIn = jsonData[i].value",
-								"            }",
-								"        }",
-								"        var hubExpectedBalance = Number(pm.environment.get(\"hubReconAccountBalanceBeforeFundsIn\"))+Number(pm.environment.get('fundsInPrepareAmount'))",
-								"        console.log(hubExpectedBalance)",
-								"        pm.test(\"Final Hub Reconciliation Account Balance should be same as before FundsIn + fundsInPrepareAmount\", function () {",
-								"            pm.expect(hubReconAccountBalanceAfterFundsIn).to.eql(hubExpectedBalance);",
-								"          });  ",
-								"    });",
-								"}, 2000)"
-							],
-							"type": "text/javascript"
-						}
-					}
-				],
-				"request": {
-					"auth": {
-						"type": "bearer",
-						"bearer": [{
-							"key": "token",
-							"value": "{{HUB_OPERATOR_BEARER_TOKEN}}",
-							"type": "string"
-						}]
-					},
-					"method": "POST",
-					"header": [{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
+			"item": [
+				{
+					"name": "Record Funds In - prepare",
+					"event": [
 						{
-							"key": "FSPIOP-Source",
-							"type": "text",
-							"value": "{{hub_operator}}"
+							"listen": "prerequest",
+							"script": {
+								"id": "a96ad88c-c5e9-4077-b060-765ccd1e86e1",
+								"exec": [
+									"var uuid = require('uuid');",
+									"var generatedUUID = uuid.v4();",
+									"pm.environment.set('fundsInPrepareTransferId', generatedUUID);",
+									"pm.environment.set('fundsInPrepareAmount', 5000);",
+									"",
+									"",
+									"const payerfspGetStatusRequest = {",
+									"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
+									"  method: 'GET',",
+									"  header: {",
+									"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+									"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+									"      \"Content-Type\": \"application/json\"",
+									"  }",
+									"};",
+									"pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
+									"    console.log(response.json())",
+									"    var jsonData = response.json()",
+									"    for(var i in jsonData) {",
+									"        if((jsonData[i].ledgerAccountType === 'SETTLEMENT') && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+									"            pm.environment.set(\"payerfspSettlementAccountId\",jsonData[i].id)",
+									"            pm.environment.set(\"payerfspSettlementAccountBalanceBeforeFundsIn\",jsonData[i].value)",
+									"        }",
+									"    }",
+									"});",
+									"",
+									"const hubGetStatusRequest = {",
+									"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
+									"  method: 'GET',",
+									"  header: {",
+									"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+									"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+									"      \"Content-Type\": \"application/json\"",
+									"  }",
+									"};",
+									"pm.sendRequest(hubGetStatusRequest, function (err, response) {",
+									"    console.log(response.json())",
+									"    var jsonData = response.json()",
+									"    for(var i in jsonData) {",
+									"        if((jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION') && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+									"            pm.environment.set(\"hubReconAccountBalanceBeforeFundsIn\",jsonData[i].value)",
+									"        }",
+									"    }",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "96c26230-6092-4f78-882f-c5343b363fe1",
+								"exec": [
+									"pm.test(\"Status code is 202\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									"",
+									"setTimeout(function () {",
+									"    const payerfspGetStatusRequest = {",
+									"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
+									"      method: 'GET',",
+									"      header: {",
+									"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+									"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+									"          \"Content-Type\": \"application/json\"",
+									"      }",
+									"    };",
+									"    pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
+									"        console.log('payerfsp accounts: ',response.json())",
+									"        var jsonData = response.json()",
+									"        var payerfspSettlementAccountBalanceAfterFundsIn",
+									"        for(var i in jsonData) {",
+									"            if(jsonData[i].ledgerAccountType === 'SETTLEMENT'  && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+									"                payerfspSettlementAccountBalanceAfterFundsIn = jsonData[i].value",
+									"            }",
+									"        }",
+									"        var payerfspExpectedBalance = -(-Number(pm.environment.get('payerfspSettlementAccountBalanceBeforeFundsIn')) + Number(pm.environment.get('fundsInPrepareAmount')))",
+									"        pm.test(\"Final Payerfsp Settlement Account Balance should be same as before FundsIn + fundsInPrepareAmount\", function () {",
+									"            pm.expect(payerfspSettlementAccountBalanceAfterFundsIn).to.eql(payerfspExpectedBalance);",
+									"          });    ",
+									"    ",
+									"    });",
+									"    ",
+									"    const hubGetStatusRequest = {",
+									"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
+									"      method: 'GET',",
+									"      header: {",
+									"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+									"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+									"          \"Content-Type\": \"application/json\"",
+									"      }",
+									"    };",
+									"    pm.sendRequest(hubGetStatusRequest, function (err, response) {",
+									"        console.log('hub accounts balance: ',response.json())",
+									"        var jsonData = response.json()",
+									"        var currentHubReconAccountBalance",
+									"        for(var i in jsonData) {",
+									"            if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION'  && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+									"                hubReconAccountBalanceAfterFundsIn = jsonData[i].value",
+									"            }",
+									"        }",
+									"        var hubExpectedBalance = Number(pm.environment.get(\"hubReconAccountBalanceBeforeFundsIn\"))+Number(pm.environment.get('fundsInPrepareAmount'))",
+									"        console.log(hubExpectedBalance)",
+									"        pm.test(\"Final Hub Reconciliation Account Balance should be same as before FundsIn + fundsInPrepareAmount\", function () {",
+									"            pm.expect(hubReconAccountBalanceAfterFundsIn).to.eql(hubExpectedBalance);",
+									"          });  ",
+									"    });",
+									"}, 2000)"
+								],
+								"type": "text/javascript"
+							}
 						}
 					],
-					"body": {
-						"mode": "raw",
-						"raw": "{\n  \"transferId\": \"{{fundsInPrepareTransferId}}\",\n  \"externalReference\": \"string\",\n  \"action\": \"recordFundsIn\",\n  \"reason\": \"string\",\n  \"amount\": {\n    \"amount\": \"{{fundsInPrepareAmount}}\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"extensionList\": {\n    \"extension\": [\n      {\n        \"key\": \"string\",\n        \"value\": \"string\"\n      }\n    ]\n  }\n}"
-					},
-					"url": {
-						"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/accounts/{{payerfspSettlementAccountId}}",
-						"host": [
-							"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{HUB_OPERATOR_BEARER_TOKEN}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "FSPIOP-Source",
+								"type": "text",
+								"value": "{{hub_operator}}"
+							}
 						],
-						"path": [
-							"participants",
-							"{{payerfsp}}",
-							"accounts",
-							"{{payerfspSettlementAccountId}}"
-						]
-					}
-				},
-				"response": []
-			},
-				{
-					"name": "Record Funds In - prepare transfer status",
-					"event": [{
-						"listen": "prerequest",
-						"script": {
-							"id": "1809507a-83ea-469d-8692-59e38cced96d",
-							"exec": [
-								"pm.environment.set('dateHeader', (new Date()).toUTCString());"
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"transferId\": \"{{fundsInPrepareTransferId}}\",\n  \"externalReference\": \"string\",\n  \"action\": \"recordFundsIn\",\n  \"reason\": \"string\",\n  \"amount\": {\n    \"amount\": \"{{fundsInPrepareAmount}}\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"extensionList\": {\n    \"extension\": [\n      {\n        \"key\": \"string\",\n        \"value\": \"string\"\n      }\n    ]\n  }\n}"
+						},
+						"url": {
+							"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/accounts/{{payerfspSettlementAccountId}}",
+							"host": [
+								"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
 							],
-							"type": "text/javascript"
+							"path": [
+								"participants",
+								"{{payerfsp}}",
+								"accounts",
+								"{{payerfspSettlementAccountId}}"
+							]
 						}
 					},
+					"response": []
+				},
+				{
+					"name": "Record Funds In - prepare transfer status",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "1809507a-83ea-469d-8692-59e38cced96d",
+								"exec": [
+									"pm.environment.set('dateHeader', (new Date()).toUTCString());"
+								],
+								"type": "text/javascript"
+							}
+						},
 						{
 							"listen": "test",
 							"script": {
@@ -1461,17 +1473,20 @@
 					"request": {
 						"auth": {
 							"type": "bearer",
-							"bearer": [{
-								"key": "token",
-								"value": "{{BEARER_TOKEN}}",
-								"type": "string"
-							}]
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BEARER_TOKEN}}",
+									"type": "string"
+								}
+							]
 						},
 						"method": "GET",
-						"header": [{
-							"key": "Accept",
-							"value": "application/vnd.interoperability.transfers+json;version=1"
-						},
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.interoperability.transfers+json;version=1"
+							},
 							{
 								"key": "Content-Type",
 								"value": "application/vnd.interoperability.transfers+json;version=1.0"
@@ -1485,10 +1500,6 @@
 								"value": "{{payerfsp}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{fundsInPrepareTransferId}}",
 							"host": [
@@ -1507,683 +1518,699 @@
 		},
 		{
 			"name": "funds_out",
-			"item": [{
-				"name": "Reserve&Commit",
-				"item": [{
-					"name": "Record Funds Out Prepare&Reserve- payerfsp",
-					"event": [{
-						"listen": "prerequest",
-						"script": {
-							"id": "a96ad88c-c5e9-4077-b060-765ccd1e86e1",
-							"exec": [
-								"var uuid = require('uuid');",
-								"var generatedUUID = uuid.v4();",
-								"pm.environment.set('fundsOutPrepareReserveTransferId', generatedUUID);",
-								"pm.environment.set('fundsOutPrepareReserveAmount', 1000);",
-								"",
-								"",
-								"const payerfspGetStatusRequest = {",
-								"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
-								"  method: 'GET',",
-								"  header: {",
-								"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-								"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-								"      \"Content-Type\": \"application/json\"",
-								"  }",
-								"};",
-								"pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
-								"    console.log(response.json())",
-								"    var jsonData = response.json()",
-								"    for(var i in jsonData) {",
-								"        if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-								"            pm.environment.set(\"payerfspSettlementAccountId\",jsonData[i].id)",
-								"            pm.environment.set(\"payerfspSettlementAccountBalanceBeforeFundsOutPrepare\",jsonData[i].value)",
-								"        }",
-								"    }",
-								"});",
-								"",
-								"const hubGetStatusRequest = {",
-								"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
-								"  method: 'GET',",
-								"  header: {",
-								"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-								"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-								"      \"Content-Type\": \"application/json\"",
-								"  }",
-								"};",
-								"pm.sendRequest(hubGetStatusRequest, function (err, response) {",
-								"    console.log(response.json())",
-								"    var jsonData = response.json()",
-								"    for(var i in jsonData) {",
-								"        if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-								"            pm.environment.set(\"hubReconAccountBalanceBeforeFundsOutPrepare\",jsonData[i].value)",
-								"        }",
-								"    }",
-								"});",
-								""
-							],
-							"type": "text/javascript"
-						}
-					},
-						{
-							"listen": "test",
-							"script": {
-								"id": "96c26230-6092-4f78-882f-c5343b363fe1",
-								"exec": [
-									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
-									"});",
-									"",
-									"setTimeout(function () {",
-									"    const payerfspGetStatusRequest = {",
-									"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
-									"      method: 'GET',",
-									"      header: {",
-									"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-									"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-									"          \"Content-Type\": \"application/json\"",
-									"      }",
-									"    };",
-									"    pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
-									"        console.log(response.json())",
-									"        var jsonData = response.json()",
-									"        var payerfspSettlementAccountBalanceAfterFundsOutPrepare",
-									"        for(var i in jsonData) {",
-									"            if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-									"                payerfspSettlementAccountBalanceAfterFundsOutPrepare = jsonData[i].value",
-									"            }",
-									"        }",
-									"        var payerfspExpectedBalance = -(-Number(pm.environment.get('payerfspSettlementAccountBalanceBeforeFundsOutPrepare'))- Number(pm.environment.get(\"fundsOutPrepareReserveAmount\")))",
-									"        pm.test(\"Final Payerfsp Settlement Account Balance should decrease by the transfer amount\", function () {",
-									"            pm.expect(payerfspSettlementAccountBalanceAfterFundsOutPrepare).to.eql(payerfspExpectedBalance);",
-									"          });    ",
-									"    ",
-									"    });",
-									"    ",
-									"    const hubGetStatusRequest = {",
-									"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
-									"      method: 'GET',",
-									"      header: {",
-									"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-									"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-									"          \"Content-Type\": \"application/json\"",
-									"      }",
-									"    };",
-									"    pm.sendRequest(hubGetStatusRequest, function (err, response) {",
-									"        console.log(response.json())",
-									"        var jsonData = response.json()",
-									"        var hubReconAccountBalanceAfterFundsOutPrepare",
-									"        for(var i in jsonData) {",
-									"            if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-									"                hubReconAccountBalanceAfterFundsOutPrepare = jsonData[i].value",
-									"            }",
-									"        }",
-									"        var hubExpectedBalance = pm.environment.get(\"hubReconAccountBalanceBeforeFundsOutPrepare\")//-pm.environment.get(\"fundsOutPrepareReserveAmount\")",
-									"        pm.test(\"Final Hub Reconciliation Account Balance should stay the same in prepare phase\", function () {",
-									"            pm.expect(hubReconAccountBalanceAfterFundsOutPrepare).to.eql(hubExpectedBalance);",
-									"          });  ",
-									"    });",
-									"}, 2000)"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [{
-								"key": "token",
-								"value": "{{HUB_OPERATOR_BEARER_TOKEN}}",
-								"type": "string"
-							}]
-						},
-						"method": "POST",
-						"header": [{
-							"key": "Content-Type",
-							"value": "application/json"
-						},
-							{
-								"key": "FSPIOP-Source",
-								"type": "text",
-								"value": "{{hub_operator}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"transferId\": \"{{fundsOutPrepareReserveTransferId}}\",\n  \"externalReference\": \"string\",\n  \"action\": \"recordFundsOutPrepareReserve\",\n  \"reason\": \"string\",\n  \"amount\": {\n    \"amount\": {{fundsOutPrepareReserveAmount}},\n    \"currency\": \"{{currency}}\"\n  },\n  \"extensionList\": {\n    \"extension\": [\n      {\n        \"key\": \"string\",\n        \"value\": \"string\"\n      }\n    ]\n  }\n}"
-						},
-						"url": {
-							"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/accounts/{{payerfspSettlementAccountId}}",
-							"host": [
-								"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-							],
-							"path": [
-								"participants",
-								"{{payerfsp}}",
-								"accounts",
-								"{{payerfspSettlementAccountId}}"
-							]
-						}
-					},
-					"response": []
-				},
-					{
-						"name": "Record Funds Out Prepare&Reserve - transfer status",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "1809507a-83ea-469d-8692-59e38cced96d",
-								"exec": [
-									"pm.environment.set('dateHeader', (new Date()).toUTCString());"
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "db933910-0ef6-406a-bed5-76e74347f533",
-									"exec": [
-										"pm.test(\"Status code is 202\", function () {",
-										"    pm.response.to.have.status(202);",
-										"});",
-										"",
-										"setTimeout(function () {",
-										"    ",
-										"    const getTransferResponse = {",
-										"      url: pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"fundsOutPrepareReserveTransferId\"),",
-										"      method: 'GET',",
-										"      header: {",
-										"          \"Authorization\":\"Bearer \"+pm.environment.get(\"BEARER_TOKEN\"),",
-										"          \"FSPIOP-Source\": pm.environment.get(\"payerfsp\"),",
-										"          \"Content-Type\": \"application/json\"",
-										"      }",
-										"    };",
-										"    pm.sendRequest(getTransferResponse, function (err, response) {",
-										"        var jsonData = response.json().data",
-										"        pm.test(\"Transfer State should be RESERVED\", function () {",
-										"            pm.expect(jsonData.transferState).to.eql(\"RESERVED\");",
-										"          });    ",
-										"    ",
-										"    });",
-										"}, 2000)"
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "GET",
-							"header": [{
-								"key": "Accept",
-								"value": "application/vnd.interoperability.transfers+json;version=1"
-							},
-								{
-									"key": "Content-Type",
-									"value": "application/vnd.interoperability.transfers+json;version=1.0"
-								},
-								{
-									"key": "Date",
-									"value": "{{dateHeader}}"
-								},
-								{
-									"key": "FSPIOP-Source",
-									"value": "{{payerfsp}}"
-								}
-							],
-							"body": {
-								"mode": "raw",
-								"raw": ""
-							},
-							"url": {
-								"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{fundsOutPrepareReserveTransferId}}",
-								"host": [
-									"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-								],
-								"path": [
-									"transfers",
-									"{{fundsOutPrepareReserveTransferId}}"
-								]
-							},
-							"description": "The HTTP request GET /transfers/<ID> is used to get information regarding an earlier created or requested transfer. The <ID> in the URI should contain the transferId that was used for the creation of the transfer."
-						},
-						"response": []
-					},
-					{
-						"name": "Record Funds Out Commit - payerfsp",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "a96ad88c-c5e9-4077-b060-765ccd1e86e1",
-								"exec": [
-									"var uuid = require('uuid');",
-									"var generatedUUID = uuid.v4();",
-									"pm.environment.set('fundsOutCommitTransferId', generatedUUID);",
-									"pm.environment.set('fundsOutCommitAmount', 1000);",
-									"",
-									"",
-									"const payerfspGetStatusRequest = {",
-									"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
-									"  method: 'GET',",
-									"  header: {",
-									"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
-									"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-									"      \"Content-Type\": \"application/json\"",
-									"  }",
-									"};",
-									"pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
-									"    console.log(response.json())",
-									"    var jsonData = response.json()",
-									"    for(var i in jsonData) {",
-									"        if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-									"            pm.environment.set(\"payerfspSettlementAccountBalanceBeforeFundsOutCommit\",jsonData[i].value)",
-									"        }",
-									"    }",
-									"});",
-									"",
-									"const hubGetStatusRequest = {",
-									"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
-									"  method: 'GET',",
-									"  header: {",
-									"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
-									"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-									"      \"Content-Type\": \"application/json\"",
-									"  }",
-									"};",
-									"pm.sendRequest(hubGetStatusRequest, function (err, response) {",
-									"    console.log(response.json())",
-									"    var jsonData = response.json()",
-									"    for(var i in jsonData) {",
-									"        if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-									"            pm.environment.set(\"hubReconAccountBalanceBeforeFundsOutCommit\",jsonData[i].value)",
-									"        }",
-									"    }",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "96c26230-6092-4f78-882f-c5343b363fe1",
-									"exec": [
-										"pm.test(\"Status code is 202\", function () {",
-										"    pm.response.to.have.status(202);",
-										"});",
-										"",
-										"setTimeout(function () {",
-										"    const payerfspGetStatusRequest = {",
-										"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
-										"      method: 'GET',",
-										"      header: {",
-										"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
-										"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-										"          \"Content-Type\": \"application/json\"",
-										"      }",
-										"    };",
-										"    pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
-										"        console.log(response.json())",
-										"        var jsonData = response.json()",
-										"        var payerfspSettlementAccountBalanceAfterFundsOutCommit",
-										"        for(var i in jsonData) {",
-										"            if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-										"                payerfspSettlementAccountBalanceAfterFundsOutCommit = jsonData[i].value",
-										"            }",
-										"        }",
-										"        var payerfspExpectedBalance = pm.environment.get('payerfspSettlementAccountBalanceBeforeFundsOutCommit')//-pm.environment.get(\"fundsOutPrepareAmount\")",
-										"        pm.test(\"Final Payerfsp Settlement Account Balance should not change during commit phase\", function () {",
-										"            pm.expect(payerfspSettlementAccountBalanceAfterFundsOutCommit).to.eql(payerfspExpectedBalance);",
-										"          });    ",
-										"    ",
-										"    });",
-										"    ",
-										"    const hubGetStatusRequest = {",
-										"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
-										"      method: 'GET',",
-										"      header: {",
-										"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
-										"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-										"          \"Content-Type\": \"application/json\"",
-										"      }",
-										"    };",
-										"    pm.sendRequest(hubGetStatusRequest, function (err, response) {",
-										"        console.log(response.json())",
-										"        var jsonData = response.json()",
-										"        var hubReconAccountBalanceAfterFundsOutCommit",
-										"        for(var i in jsonData) {",
-										"            if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-										"                hubReconAccountBalanceAfterFundsOutCommit = jsonData[i].value",
-										"            }",
-										"        }",
-										"        var hubExpectedBalance = Number(pm.environment.get(\"hubReconAccountBalanceBeforeFundsOutCommit\")) - Number(pm.environment.get(\"fundsOutCommitAmount\"))",
-										"        pm.test(\"Final Hub Reconciliation Account Balance should decrease by the transfer amount\", function () {",
-										"            pm.expect(hubReconAccountBalanceAfterFundsOutCommit).to.eql(hubExpectedBalance);",
-										"          });  ",
-										"    });",
-										"}, 2000)"
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{HUBOPERATOR_BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "PUT",
-							"header": [{
-								"key": "Content-Type",
-								"value": "application/json"
-							},
-								{
-									"key": "FSPIOP-Source",
-									"type": "text",
-									"value": "{{hub_operator}}"
-								}
-							],
-							"body": {
-								"mode": "raw",
-								"raw": "{\n  \"action\": \"recordFundsOutCommit\",\n  \"reason\": \"Reason for out flow of funds\"\n}"
-							},
-							"url": {
-								"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/accounts/{{payerfspSettlementAccountId}}/transfers/{{fundsOutPrepareReserveTransferId}}",
-								"host": [
-									"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-								],
-								"path": [
-									"participants",
-									"{{payerfsp}}",
-									"accounts",
-									"{{payerfspSettlementAccountId}}",
-									"transfers",
-									"{{fundsOutPrepareReserveTransferId}}"
-								]
-							}
-						},
-						"response": []
-					},
-					{
-						"name": "Record Funds Out Commit - transfer status",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "1809507a-83ea-469d-8692-59e38cced96d",
-								"exec": [
-									"pm.environment.set('dateHeader', (new Date()).toUTCString());"
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "db933910-0ef6-406a-bed5-76e74347f533",
-									"exec": [
-										"pm.test(\"Status code is 202\", function () {",
-										"    pm.response.to.have.status(202);",
-										"});",
-										"",
-										"setTimeout(function () {",
-										"    ",
-										"    const getTransferResponse = {",
-										"      url: pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"fundsOutPrepareReserveTransferId\"),",
-										"      method: 'GET',",
-										"      header: {",
-										"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
-										"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-										"          \"Content-Type\": \"application/json\"",
-										"      }",
-										"    };",
-										"    pm.sendRequest(getTransferResponse, function (err, response) {",
-										"        var jsonData = response.json().data",
-										"        pm.test(\"Transfer State should be COMMITTED\", function () {",
-										"            pm.expect(jsonData.transferState).to.eql(\"COMMITTED\");",
-										"          });    ",
-										"    ",
-										"    });",
-										"}, 2000)"
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "b3d74594-fa41-3581-acf6-4909aaec8134",
-									"type": "string"
-								}]
-							},
-							"method": "GET",
-							"header": [{
-								"key": "Accept",
-								"value": "application/vnd.interoperability.transfers+json;version=1"
-							},
-								{
-									"key": "Content-Type",
-									"value": "application/vnd.interoperability.transfers+json;version=1.0"
-								},
-								{
-									"key": "Date",
-									"value": "{{dateHeader}}"
-								},
-								{
-									"key": "FSPIOP-Source",
-									"value": "{{payerfsp}}"
-								}
-							],
-							"body": {
-								"mode": "raw",
-								"raw": ""
-							},
-							"url": {
-								"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{fundsOutPrepareReserveTransferId}}",
-								"host": [
-									"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-								],
-								"path": [
-									"transfers",
-									"{{fundsOutPrepareReserveTransferId}}"
-								]
-							},
-							"description": "The HTTP request GET /transfers/<ID> is used to get information regarding an earlier created or requested transfer. The <ID> in the URI should contain the transferId that was used for the creation of the transfer."
-						},
-						"response": []
-					}
-				],
-				"_postman_isSubFolder": true
-			},
+			"item": [
 				{
-					"name": "Reserve&Abort",
-					"item": [{
-						"name": "Record Funds Out Prepare&Reserve- payerfsp",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "a96ad88c-c5e9-4077-b060-765ccd1e86e1",
-								"exec": [
-									"var uuid = require('uuid');",
-									"var generatedUUID = uuid.v4();",
-									"pm.environment.set('fundsOutPrepareReserveTransferId', generatedUUID);",
-									"pm.environment.set('fundsOutPrepareReserveAmount', 1000);",
-									"",
-									"",
-									"const payerfspGetStatusRequest = {",
-									"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
-									"  method: 'GET',",
-									"  header: {",
-									"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-									"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-									"      \"Content-Type\": \"application/json\"",
-									"  }",
-									"};",
-									"pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
-									"    console.log(response.json())",
-									"    var jsonData = response.json()",
-									"    for(var i in jsonData) {",
-									"        if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-									"            pm.environment.set(\"payerfspSettlementAccountId\",jsonData[i].id)",
-									"            pm.environment.set(\"payerfspSettlementAccountBalanceBeforeFundsOutPrepare\",jsonData[i].value)",
-									"        }",
-									"    }",
-									"});",
-									"",
-									"const hubGetStatusRequest = {",
-									"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
-									"  method: 'GET',",
-									"  header: {",
-									"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-									"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-									"      \"Content-Type\": \"application/json\"",
-									"  }",
-									"};",
-									"pm.sendRequest(hubGetStatusRequest, function (err, response) {",
-									"    console.log(response.json())",
-									"    var jsonData = response.json()",
-									"    for(var i in jsonData) {",
-									"        if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-									"            pm.environment.set(\"hubReconAccountBalanceBeforeFundsOutPrepare\",jsonData[i].value)",
-									"        }",
-									"    }",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "96c26230-6092-4f78-882f-c5343b363fe1",
-									"exec": [
-										"pm.test(\"Status code is 202\", function () {",
-										"    pm.response.to.have.status(202);",
-										"});",
-										"",
-										"setTimeout(function () {",
-										"    const payerfspGetStatusRequest = {",
-										"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
-										"      method: 'GET',",
-										"      header: {",
-										"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-										"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-										"          \"Content-Type\": \"application/json\"",
-										"      }",
-										"    };",
-										"    pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
-										"        console.log(response.json())",
-										"        var jsonData = response.json()",
-										"        var payerfspSettlementAccountBalanceAfterFundsOutPrepare",
-										"        for(var i in jsonData) {",
-										"            if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-										"                payerfspSettlementAccountBalanceAfterFundsOutPrepare = jsonData[i].value",
-										"            }",
-										"        }",
-										"        var payerfspExpectedBalance = -(-Number(pm.environment.get('payerfspSettlementAccountBalanceBeforeFundsOutPrepare'))- Number(pm.environment.get(\"fundsOutPrepareReserveAmount\")))",
-										"        pm.test(\"Final Payerfsp Settlement Account Balance should decrease by the transfer amount\", function () {",
-										"            pm.expect(payerfspSettlementAccountBalanceAfterFundsOutPrepare).to.eql(payerfspExpectedBalance);",
-										"          });    ",
-										"    ",
-										"    });",
-										"    ",
-										"    const hubGetStatusRequest = {",
-										"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
-										"      method: 'GET',",
-										"      header: {",
-										"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
-										"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-										"          \"Content-Type\": \"application/json\"",
-										"      }",
-										"    };",
-										"    pm.sendRequest(hubGetStatusRequest, function (err, response) {",
-										"        console.log(response.json())",
-										"        var jsonData = response.json()",
-										"        var hubReconAccountBalanceAfterFundsOutPrepare",
-										"        for(var i in jsonData) {",
-										"            if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-										"                hubReconAccountBalanceAfterFundsOutPrepare = jsonData[i].value",
-										"            }",
-										"        }",
-										"        var hubExpectedBalance = pm.environment.get(\"hubReconAccountBalanceBeforeFundsOutPrepare\")//-pm.environment.get(\"fundsOutPrepareReserveAmount\")",
-										"        pm.test(\"Final Hub Reconciliation Account Balance should stay the same in prepare phase\", function () {",
-										"            pm.expect(hubReconAccountBalanceAfterFundsOutPrepare).to.eql(hubExpectedBalance);",
-										"          });  ",
-										"    });",
-										"}, 2000)"
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{HUB_OPERATOR_BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "POST",
-							"header": [{
-								"key": "Content-Type",
-								"value": "application/json"
-							},
+					"name": "Reserve&Commit",
+					"item": [
+						{
+							"name": "Record Funds Out Prepare&Reserve- payerfsp",
+							"event": [
 								{
-									"key": "FSPIOP-Source",
-									"type": "text",
-									"value": "{{hub_operator}}"
+									"listen": "prerequest",
+									"script": {
+										"id": "a96ad88c-c5e9-4077-b060-765ccd1e86e1",
+										"exec": [
+											"var uuid = require('uuid');",
+											"var generatedUUID = uuid.v4();",
+											"pm.environment.set('fundsOutPrepareReserveTransferId', generatedUUID);",
+											"pm.environment.set('fundsOutPrepareReserveAmount', 1000);",
+											"",
+											"",
+											"const payerfspGetStatusRequest = {",
+											"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
+											"  method: 'GET',",
+											"  header: {",
+											"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+											"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"      \"Content-Type\": \"application/json\"",
+											"  }",
+											"};",
+											"pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
+											"    console.log(response.json())",
+											"    var jsonData = response.json()",
+											"    for(var i in jsonData) {",
+											"        if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"            pm.environment.set(\"payerfspSettlementAccountId\",jsonData[i].id)",
+											"            pm.environment.set(\"payerfspSettlementAccountBalanceBeforeFundsOutPrepare\",jsonData[i].value)",
+											"        }",
+											"    }",
+											"});",
+											"",
+											"const hubGetStatusRequest = {",
+											"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
+											"  method: 'GET',",
+											"  header: {",
+											"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+											"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"      \"Content-Type\": \"application/json\"",
+											"  }",
+											"};",
+											"pm.sendRequest(hubGetStatusRequest, function (err, response) {",
+											"    console.log(response.json())",
+											"    var jsonData = response.json()",
+											"    for(var i in jsonData) {",
+											"        if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"            pm.environment.set(\"hubReconAccountBalanceBeforeFundsOutPrepare\",jsonData[i].value)",
+											"        }",
+											"    }",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "96c26230-6092-4f78-882f-c5343b363fe1",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"setTimeout(function () {",
+											"    const payerfspGetStatusRequest = {",
+											"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
+											"      method: 'GET',",
+											"      header: {",
+											"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+											"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"          \"Content-Type\": \"application/json\"",
+											"      }",
+											"    };",
+											"    pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
+											"        console.log(response.json())",
+											"        var jsonData = response.json()",
+											"        var payerfspSettlementAccountBalanceAfterFundsOutPrepare",
+											"        for(var i in jsonData) {",
+											"            if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"                payerfspSettlementAccountBalanceAfterFundsOutPrepare = jsonData[i].value",
+											"            }",
+											"        }",
+											"        var payerfspExpectedBalance = -(-Number(pm.environment.get('payerfspSettlementAccountBalanceBeforeFundsOutPrepare'))- Number(pm.environment.get(\"fundsOutPrepareReserveAmount\")))",
+											"        pm.test(\"Final Payerfsp Settlement Account Balance should decrease by the transfer amount\", function () {",
+											"            pm.expect(payerfspSettlementAccountBalanceAfterFundsOutPrepare).to.eql(payerfspExpectedBalance);",
+											"          });    ",
+											"    ",
+											"    });",
+											"    ",
+											"    const hubGetStatusRequest = {",
+											"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
+											"      method: 'GET',",
+											"      header: {",
+											"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+											"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"          \"Content-Type\": \"application/json\"",
+											"      }",
+											"    };",
+											"    pm.sendRequest(hubGetStatusRequest, function (err, response) {",
+											"        console.log(response.json())",
+											"        var jsonData = response.json()",
+											"        var hubReconAccountBalanceAfterFundsOutPrepare",
+											"        for(var i in jsonData) {",
+											"            if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"                hubReconAccountBalanceAfterFundsOutPrepare = jsonData[i].value",
+											"            }",
+											"        }",
+											"        var hubExpectedBalance = pm.environment.get(\"hubReconAccountBalanceBeforeFundsOutPrepare\")//-pm.environment.get(\"fundsOutPrepareReserveAmount\")",
+											"        pm.test(\"Final Hub Reconciliation Account Balance should stay the same in prepare phase\", function () {",
+											"            pm.expect(hubReconAccountBalanceAfterFundsOutPrepare).to.eql(hubExpectedBalance);",
+											"          });  ",
+											"    });",
+											"}, 2000)"
+										],
+										"type": "text/javascript"
+									}
 								}
 							],
-							"body": {
-								"mode": "raw",
-								"raw": "{\n  \"transferId\": \"{{fundsOutPrepareReserveTransferId}}\",\n  \"externalReference\": \"string\",\n  \"action\": \"recordFundsOutPrepareReserve\",\n  \"reason\": \"string\",\n  \"amount\": {\n    \"amount\": {{fundsOutPrepareReserveAmount}},\n    \"currency\": \"{{currency}}\"\n  },\n  \"extensionList\": {\n    \"extension\": [\n      {\n        \"key\": \"string\",\n        \"value\": \"string\"\n      }\n    ]\n  }\n}"
-							},
-							"url": {
-								"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/accounts/{{payerfspSettlementAccountId}}",
-								"host": [
-									"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{HUB_OPERATOR_BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{hub_operator}}"
+									}
 								],
-								"path": [
-									"participants",
-									"{{payerfsp}}",
-									"accounts",
-									"{{payerfspSettlementAccountId}}"
-								]
-							}
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"transferId\": \"{{fundsOutPrepareReserveTransferId}}\",\n  \"externalReference\": \"string\",\n  \"action\": \"recordFundsOutPrepareReserve\",\n  \"reason\": \"string\",\n  \"amount\": {\n    \"amount\": {{fundsOutPrepareReserveAmount}},\n    \"currency\": \"{{currency}}\"\n  },\n  \"extensionList\": {\n    \"extension\": [\n      {\n        \"key\": \"string\",\n        \"value\": \"string\"\n      }\n    ]\n  }\n}"
+								},
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/accounts/{{payerfspSettlementAccountId}}",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payerfsp}}",
+										"accounts",
+										"{{payerfspSettlementAccountId}}"
+									]
+								}
+							},
+							"response": []
 						},
-						"response": []
-					},
 						{
 							"name": "Record Funds Out Prepare&Reserve - transfer status",
-							"event": [{
-								"listen": "prerequest",
-								"script": {
-									"id": "1809507a-83ea-469d-8692-59e38cced96d",
-									"exec": [
-										"pm.environment.set('dateHeader', (new Date()).toUTCString());"
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "1809507a-83ea-469d-8692-59e38cced96d",
+										"exec": [
+											"pm.environment.set('dateHeader', (new Date()).toUTCString());"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "db933910-0ef6-406a-bed5-76e74347f533",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"setTimeout(function () {",
+											"    ",
+											"    const getTransferResponse = {",
+											"      url: pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"fundsOutPrepareReserveTransferId\"),",
+											"      method: 'GET',",
+											"      header: {",
+											"          \"Authorization\":\"Bearer \"+pm.environment.get(\"BEARER_TOKEN\"),",
+											"          \"FSPIOP-Source\": pm.environment.get(\"payerfsp\"),",
+											"          \"Content-Type\": \"application/json\"",
+											"      }",
+											"    };",
+											"    pm.sendRequest(getTransferResponse, function (err, response) {",
+											"        var jsonData = response.json().data",
+											"        pm.test(\"Transfer State should be RESERVED\", function () {",
+											"            pm.expect(jsonData.transferState).to.eql(\"RESERVED\");",
+											"          });    ",
+											"    ",
+											"    });",
+											"}, 2000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.transfers+json;version=1.0"
+									},
+									{
+										"key": "Date",
+										"value": "{{dateHeader}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{fundsOutPrepareReserveTransferId}}",
+									"host": [
+										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
 									],
-									"type": "text/javascript"
+									"path": [
+										"transfers",
+										"{{fundsOutPrepareReserveTransferId}}"
+									]
+								},
+								"description": "The HTTP request GET /transfers/<ID> is used to get information regarding an earlier created or requested transfer. The <ID> in the URI should contain the transferId that was used for the creation of the transfer."
+							},
+							"response": []
+						},
+						{
+							"name": "Record Funds Out Commit - payerfsp",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a96ad88c-c5e9-4077-b060-765ccd1e86e1",
+										"exec": [
+											"var uuid = require('uuid');",
+											"var generatedUUID = uuid.v4();",
+											"pm.environment.set('fundsOutCommitTransferId', generatedUUID);",
+											"pm.environment.set('fundsOutCommitAmount', 1000);",
+											"",
+											"",
+											"const payerfspGetStatusRequest = {",
+											"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
+											"  method: 'GET',",
+											"  header: {",
+											"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
+											"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"      \"Content-Type\": \"application/json\"",
+											"  }",
+											"};",
+											"pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
+											"    console.log(response.json())",
+											"    var jsonData = response.json()",
+											"    for(var i in jsonData) {",
+											"        if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"            pm.environment.set(\"payerfspSettlementAccountBalanceBeforeFundsOutCommit\",jsonData[i].value)",
+											"        }",
+											"    }",
+											"});",
+											"",
+											"const hubGetStatusRequest = {",
+											"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
+											"  method: 'GET',",
+											"  header: {",
+											"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
+											"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"      \"Content-Type\": \"application/json\"",
+											"  }",
+											"};",
+											"pm.sendRequest(hubGetStatusRequest, function (err, response) {",
+											"    console.log(response.json())",
+											"    var jsonData = response.json()",
+											"    for(var i in jsonData) {",
+											"        if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"            pm.environment.set(\"hubReconAccountBalanceBeforeFundsOutCommit\",jsonData[i].value)",
+											"        }",
+											"    }",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "96c26230-6092-4f78-882f-c5343b363fe1",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"setTimeout(function () {",
+											"    const payerfspGetStatusRequest = {",
+											"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
+											"      method: 'GET',",
+											"      header: {",
+											"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
+											"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"          \"Content-Type\": \"application/json\"",
+											"      }",
+											"    };",
+											"    pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
+											"        console.log(response.json())",
+											"        var jsonData = response.json()",
+											"        var payerfspSettlementAccountBalanceAfterFundsOutCommit",
+											"        for(var i in jsonData) {",
+											"            if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"                payerfspSettlementAccountBalanceAfterFundsOutCommit = jsonData[i].value",
+											"            }",
+											"        }",
+											"        var payerfspExpectedBalance = pm.environment.get('payerfspSettlementAccountBalanceBeforeFundsOutCommit')//-pm.environment.get(\"fundsOutPrepareAmount\")",
+											"        pm.test(\"Final Payerfsp Settlement Account Balance should not change during commit phase\", function () {",
+											"            pm.expect(payerfspSettlementAccountBalanceAfterFundsOutCommit).to.eql(payerfspExpectedBalance);",
+											"          });    ",
+											"    ",
+											"    });",
+											"    ",
+											"    const hubGetStatusRequest = {",
+											"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
+											"      method: 'GET',",
+											"      header: {",
+											"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
+											"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"          \"Content-Type\": \"application/json\"",
+											"      }",
+											"    };",
+											"    pm.sendRequest(hubGetStatusRequest, function (err, response) {",
+											"        console.log(response.json())",
+											"        var jsonData = response.json()",
+											"        var hubReconAccountBalanceAfterFundsOutCommit",
+											"        for(var i in jsonData) {",
+											"            if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"                hubReconAccountBalanceAfterFundsOutCommit = jsonData[i].value",
+											"            }",
+											"        }",
+											"        var hubExpectedBalance = Number(pm.environment.get(\"hubReconAccountBalanceBeforeFundsOutCommit\")) - Number(pm.environment.get(\"fundsOutCommitAmount\"))",
+											"        pm.test(\"Final Hub Reconciliation Account Balance should decrease by the transfer amount\", function () {",
+											"            pm.expect(hubReconAccountBalanceAfterFundsOutCommit).to.eql(hubExpectedBalance);",
+											"          });  ",
+											"    });",
+											"}, 2000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{HUBOPERATOR_BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{hub_operator}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"action\": \"recordFundsOutCommit\",\n  \"reason\": \"Reason for out flow of funds\"\n}"
+								},
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/accounts/{{payerfspSettlementAccountId}}/transfers/{{fundsOutPrepareReserveTransferId}}",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payerfsp}}",
+										"accounts",
+										"{{payerfspSettlementAccountId}}",
+										"transfers",
+										"{{fundsOutPrepareReserveTransferId}}"
+									]
 								}
 							},
+							"response": []
+						},
+						{
+							"name": "Record Funds Out Commit - transfer status",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "1809507a-83ea-469d-8692-59e38cced96d",
+										"exec": [
+											"pm.environment.set('dateHeader', (new Date()).toUTCString());"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "db933910-0ef6-406a-bed5-76e74347f533",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"setTimeout(function () {",
+											"    ",
+											"    const getTransferResponse = {",
+											"      url: pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"fundsOutPrepareReserveTransferId\"),",
+											"      method: 'GET',",
+											"      header: {",
+											"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
+											"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"          \"Content-Type\": \"application/json\"",
+											"      }",
+											"    };",
+											"    pm.sendRequest(getTransferResponse, function (err, response) {",
+											"        var jsonData = response.json().data",
+											"        pm.test(\"Transfer State should be COMMITTED\", function () {",
+											"            pm.expect(jsonData.transferState).to.eql(\"COMMITTED\");",
+											"          });    ",
+											"    ",
+											"    });",
+											"}, 2000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "b3d74594-fa41-3581-acf6-4909aaec8134",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.transfers+json;version=1.0"
+									},
+									{
+										"key": "Date",
+										"value": "{{dateHeader}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{fundsOutPrepareReserveTransferId}}",
+									"host": [
+										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+									],
+									"path": [
+										"transfers",
+										"{{fundsOutPrepareReserveTransferId}}"
+									]
+								},
+								"description": "The HTTP request GET /transfers/<ID> is used to get information regarding an earlier created or requested transfer. The <ID> in the URI should contain the transferId that was used for the creation of the transfer."
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Reserve&Abort",
+					"item": [
+						{
+							"name": "Record Funds Out Prepare&Reserve- payerfsp",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a96ad88c-c5e9-4077-b060-765ccd1e86e1",
+										"exec": [
+											"var uuid = require('uuid');",
+											"var generatedUUID = uuid.v4();",
+											"pm.environment.set('fundsOutPrepareReserveTransferId', generatedUUID);",
+											"pm.environment.set('fundsOutPrepareReserveAmount', 1000);",
+											"",
+											"",
+											"const payerfspGetStatusRequest = {",
+											"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
+											"  method: 'GET',",
+											"  header: {",
+											"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+											"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"      \"Content-Type\": \"application/json\"",
+											"  }",
+											"};",
+											"pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
+											"    console.log(response.json())",
+											"    var jsonData = response.json()",
+											"    for(var i in jsonData) {",
+											"        if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"            pm.environment.set(\"payerfspSettlementAccountId\",jsonData[i].id)",
+											"            pm.environment.set(\"payerfspSettlementAccountBalanceBeforeFundsOutPrepare\",jsonData[i].value)",
+											"        }",
+											"    }",
+											"});",
+											"",
+											"const hubGetStatusRequest = {",
+											"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
+											"  method: 'GET',",
+											"  header: {",
+											"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+											"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"      \"Content-Type\": \"application/json\"",
+											"  }",
+											"};",
+											"pm.sendRequest(hubGetStatusRequest, function (err, response) {",
+											"    console.log(response.json())",
+											"    var jsonData = response.json()",
+											"    for(var i in jsonData) {",
+											"        if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"            pm.environment.set(\"hubReconAccountBalanceBeforeFundsOutPrepare\",jsonData[i].value)",
+											"        }",
+											"    }",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "96c26230-6092-4f78-882f-c5343b363fe1",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"setTimeout(function () {",
+											"    const payerfspGetStatusRequest = {",
+											"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
+											"      method: 'GET',",
+											"      header: {",
+											"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+											"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"          \"Content-Type\": \"application/json\"",
+											"      }",
+											"    };",
+											"    pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
+											"        console.log(response.json())",
+											"        var jsonData = response.json()",
+											"        var payerfspSettlementAccountBalanceAfterFundsOutPrepare",
+											"        for(var i in jsonData) {",
+											"            if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"                payerfspSettlementAccountBalanceAfterFundsOutPrepare = jsonData[i].value",
+											"            }",
+											"        }",
+											"        var payerfspExpectedBalance = -(-Number(pm.environment.get('payerfspSettlementAccountBalanceBeforeFundsOutPrepare'))- Number(pm.environment.get(\"fundsOutPrepareReserveAmount\")))",
+											"        pm.test(\"Final Payerfsp Settlement Account Balance should decrease by the transfer amount\", function () {",
+											"            pm.expect(payerfspSettlementAccountBalanceAfterFundsOutPrepare).to.eql(payerfspExpectedBalance);",
+											"          });    ",
+											"    ",
+											"    });",
+											"    ",
+											"    const hubGetStatusRequest = {",
+											"      url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
+											"      method: 'GET',",
+											"      header: {",
+											"          \"Authorization\":\"Bearer \"+pm.environment.get(\"HUB_OPERATOR_BEARER_TOKEN\"),",
+											"          \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"          \"Content-Type\": \"application/json\"",
+											"      }",
+											"    };",
+											"    pm.sendRequest(hubGetStatusRequest, function (err, response) {",
+											"        console.log(response.json())",
+											"        var jsonData = response.json()",
+											"        var hubReconAccountBalanceAfterFundsOutPrepare",
+											"        for(var i in jsonData) {",
+											"            if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"                hubReconAccountBalanceAfterFundsOutPrepare = jsonData[i].value",
+											"            }",
+											"        }",
+											"        var hubExpectedBalance = pm.environment.get(\"hubReconAccountBalanceBeforeFundsOutPrepare\")//-pm.environment.get(\"fundsOutPrepareReserveAmount\")",
+											"        pm.test(\"Final Hub Reconciliation Account Balance should stay the same in prepare phase\", function () {",
+											"            pm.expect(hubReconAccountBalanceAfterFundsOutPrepare).to.eql(hubExpectedBalance);",
+											"          });  ",
+											"    });",
+											"}, 2000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{HUB_OPERATOR_BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{hub_operator}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"transferId\": \"{{fundsOutPrepareReserveTransferId}}\",\n  \"externalReference\": \"string\",\n  \"action\": \"recordFundsOutPrepareReserve\",\n  \"reason\": \"string\",\n  \"amount\": {\n    \"amount\": {{fundsOutPrepareReserveAmount}},\n    \"currency\": \"{{currency}}\"\n  },\n  \"extensionList\": {\n    \"extension\": [\n      {\n        \"key\": \"string\",\n        \"value\": \"string\"\n      }\n    ]\n  }\n}"
+								},
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/accounts/{{payerfspSettlementAccountId}}",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payerfsp}}",
+										"accounts",
+										"{{payerfspSettlementAccountId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Record Funds Out Prepare&Reserve - transfer status",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "1809507a-83ea-469d-8692-59e38cced96d",
+										"exec": [
+											"pm.environment.set('dateHeader', (new Date()).toUTCString());"
+										],
+										"type": "text/javascript"
+									}
+								},
 								{
 									"listen": "test",
 									"script": {
@@ -2221,17 +2248,20 @@
 							"request": {
 								"auth": {
 									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
 								},
 								"method": "GET",
-								"header": [{
-									"key": "Accept",
-									"value": "application/vnd.interoperability.transfers+json;version=1"
-								},
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
 									{
 										"key": "Content-Type",
 										"value": "application/vnd.interoperability.transfers+json;version=1.0"
@@ -2245,10 +2275,6 @@
 										"value": "{{payerfsp}}"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{fundsOutPrepareReserveTransferId}}",
 									"host": [
@@ -2265,58 +2291,59 @@
 						},
 						{
 							"name": "Record Funds Out Abort - payerfsp",
-							"event": [{
-								"listen": "prerequest",
-								"script": {
-									"id": "a96ad88c-c5e9-4077-b060-765ccd1e86e1",
-									"exec": [
-										"var uuid = require('uuid');",
-										"var generatedUUID = uuid.v4();",
-										"pm.environment.set('fundsOutCommitAmount', 1000);",
-										"",
-										"",
-										"const payerfspGetStatusRequest = {",
-										"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
-										"  method: 'GET',",
-										"  header: {",
-										"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
-										"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-										"      \"Content-Type\": \"application/json\"",
-										"  }",
-										"};",
-										"pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
-										"    console.log(response.json())",
-										"    var jsonData = response.json()",
-										"    for(var i in jsonData) {",
-										"        if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-										"            pm.environment.set(\"payerfspSettlementAccountBalanceBeforeFundsOutAbort\",jsonData[i].value)",
-										"        }",
-										"    }",
-										"});",
-										"",
-										"const hubGetStatusRequest = {",
-										"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
-										"  method: 'GET',",
-										"  header: {",
-										"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
-										"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-										"      \"Content-Type\": \"application/json\"",
-										"  }",
-										"};",
-										"pm.sendRequest(hubGetStatusRequest, function (err, response) {",
-										"    console.log(response.json())",
-										"    var jsonData = response.json()",
-										"    for(var i in jsonData) {",
-										"        if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
-										"            pm.environment.set(\"hubReconAccountBalanceBeforeFundsOutAbort\",jsonData[i].value)",
-										"        }",
-										"    }",
-										"});",
-										""
-									],
-									"type": "text/javascript"
-								}
-							},
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a96ad88c-c5e9-4077-b060-765ccd1e86e1",
+										"exec": [
+											"var uuid = require('uuid');",
+											"var generatedUUID = uuid.v4();",
+											"pm.environment.set('fundsOutCommitAmount', 1000);",
+											"",
+											"",
+											"const payerfspGetStatusRequest = {",
+											"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/'+pm.environment.get(\"payerfsp\")+'/accounts',",
+											"  method: 'GET',",
+											"  header: {",
+											"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
+											"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"      \"Content-Type\": \"application/json\"",
+											"  }",
+											"};",
+											"pm.sendRequest(payerfspGetStatusRequest, function (err, response) {",
+											"    console.log(response.json())",
+											"    var jsonData = response.json()",
+											"    for(var i in jsonData) {",
+											"        if(jsonData[i].ledgerAccountType === 'SETTLEMENT' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"            pm.environment.set(\"payerfspSettlementAccountBalanceBeforeFundsOutAbort\",jsonData[i].value)",
+											"        }",
+											"    }",
+											"});",
+											"",
+											"const hubGetStatusRequest = {",
+											"  url: pm.environment.get(\"HOST_CENTRAL_LEDGER\")+pm.environment.get(\"BASE_CENTRAL_LEDGER_ADMIN\")+'/participants/hub/accounts',",
+											"  method: 'GET',",
+											"  header: {",
+											"      \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
+											"      \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+											"      \"Content-Type\": \"application/json\"",
+											"  }",
+											"};",
+											"pm.sendRequest(hubGetStatusRequest, function (err, response) {",
+											"    console.log(response.json())",
+											"    var jsonData = response.json()",
+											"    for(var i in jsonData) {",
+											"        if(jsonData[i].ledgerAccountType === 'HUB_RECONCILIATION' && (jsonData[i].currency === pm.environment.get(\"currency\"))) {",
+											"            pm.environment.set(\"hubReconAccountBalanceBeforeFundsOutAbort\",jsonData[i].value)",
+											"        }",
+											"    }",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
 								{
 									"listen": "test",
 									"script": {
@@ -2384,17 +2411,20 @@
 							"request": {
 								"auth": {
 									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{HUBOPERATOR_BEARER_TOKEN}}",
-										"type": "string"
-									}]
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{HUBOPERATOR_BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
 								},
 								"method": "PUT",
-								"header": [{
-									"key": "Content-Type",
-									"value": "application/json"
-								},
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
 									{
 										"key": "FSPIOP-Source",
 										"type": "text",
@@ -2424,16 +2454,17 @@
 						},
 						{
 							"name": "Record Funds Out Abort - transfer status",
-							"event": [{
-								"listen": "prerequest",
-								"script": {
-									"id": "1809507a-83ea-469d-8692-59e38cced96d",
-									"exec": [
-										"pm.environment.set('dateHeader', (new Date()).toUTCString());"
-									],
-									"type": "text/javascript"
-								}
-							},
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "1809507a-83ea-469d-8692-59e38cced96d",
+										"exec": [
+											"pm.environment.set('dateHeader', (new Date()).toUTCString());"
+										],
+										"type": "text/javascript"
+									}
+								},
 								{
 									"listen": "test",
 									"script": {
@@ -2471,17 +2502,20 @@
 							"request": {
 								"auth": {
 									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "b3d74594-fa41-3581-acf6-4909aaec8134",
-										"type": "string"
-									}]
+									"bearer": [
+										{
+											"key": "token",
+											"value": "b3d74594-fa41-3581-acf6-4909aaec8134",
+											"type": "string"
+										}
+									]
 								},
 								"method": "GET",
-								"header": [{
-									"key": "Accept",
-									"value": "application/vnd.interoperability.transfers+json;version=1"
-								},
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
 									{
 										"key": "Content-Type",
 										"value": "application/vnd.interoperability.transfers+json;version=1.0"
@@ -2495,10 +2529,6 @@
 										"value": "{{payerfsp}}"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{fundsOutPrepareReserveTransferId}}",
 									"host": [
@@ -2520,1964 +2550,2406 @@
 		},
 		{
 			"name": "settlement_management",
-			"item": [{
-				"name": "SETTLE  settlement",
-				"item": [{
-					"name": "Setup Settlement",
-					"item": [{
-						"name": "Store Settlement&Position Account Balances Before Transfers",
-						"item": [{
-							"name": "testfsp1 balances",
-							"event": [{
-								"listen": "test",
-								"script": {
-									"id": "22c316ff-8ffd-4e54-b450-d12deb6e40b0",
-									"exec": [
-										"pm.test(\"Status code is 200\", function () {",
-										"    pm.response.to.have.status(200);",
-										"});",
-										"",
-										"var jsonData = pm.response.json();",
-										"for (var i in jsonData){",
-										"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-										"        console.log(jsonData[i].value)",
-										"        pm.environment.set(\"testfsp1SettleAccountBalanceBeforeTransfer\", jsonData[i].value);",
-										"    }",
-										"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-										"        console.log(jsonData[i].value)",
-										"        pm.environment.set(\"testfsp1PositionAccountBalanceBeforeTransfer\", jsonData[i].value);",
-										"    }",
-										"}",
-										"",
-										""
-									],
-									"type": "text/javascript"
-								}
-							}],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
-								},
-								"method": "GET",
-								"header": [{
-									"key": "FSPIOP-Source",
-									"value": "payerfsp",
-									"type": "text"
-								}],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
-									"host": [
-										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-									],
-									"path": [
-										"participants",
-										"testfsp1",
-										"accounts"
-									]
-								}
-							},
-							"response": []
-						},
-							{
-								"name": "testfsp2 balances",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        console.log(jsonData[i].value)",
-											"        pm.environment.set(\"testfsp2SettleAccountBalanceBeforeTransfer\", jsonData[i].value);",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        console.log(jsonData[i].value)",
-											"        pm.environment.set(\"testfsp2PositionAccountBalanceBeforeTransfer\", jsonData[i].value);",
-											"    }",
-											"}",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"auth": {
-										"type": "bearer",
-										"bearer": [{
-											"key": "token",
-											"value": "{{BEARER_TOKEN}}",
-											"type": "string"
-										}]
-									},
-									"method": "GET",
-									"header": [{
-										"key": "FSPIOP-Source",
-										"value": "payerfsp",
-										"type": "text"
-									}],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp2/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp2",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp3 balances",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        console.log(jsonData[i].value)",
-											"        pm.environment.set(\"testfsp3SettleAccountBalanceBeforeTransfer\", jsonData[i].value);",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        console.log(jsonData[i].value)",
-											"        pm.environment.set(\"testfsp3PositionAccountBalanceBeforeTransfer\", jsonData[i].value);",
-											"    }",
-											"}",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"auth": {
-										"type": "bearer",
-										"bearer": [{
-											"key": "token",
-											"value": "{{BEARER_TOKEN}}",
-											"type": "string"
-										}]
-									},
-									"method": "GET",
-									"header": [{
-										"key": "FSPIOP-Source",
-										"value": "payerfsp",
-										"type": "text"
-									}],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp3/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp3",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp4 balances",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        console.log(jsonData[i].value)",
-											"        pm.environment.set(\"testfsp4SettleAccountBalanceBeforeTransfer\", jsonData[i].value);",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        console.log(jsonData[i].value)",
-											"        pm.environment.set(\"testfsp4PositionAccountBalanceBeforeTransfer\", jsonData[i].value);",
-											"    }",
-											"}",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"auth": {
-										"type": "bearer",
-										"bearer": [{
-											"key": "token",
-											"value": "{{BEARER_TOKEN}}",
-											"type": "string"
-										}]
-									},
-									"method": "GET",
-									"header": [{
-										"key": "FSPIOP-Source",
-										"value": "payerfsp",
-										"type": "text"
-									}],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp4/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp4",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							}
-						],
-						"_postman_isSubFolder": true
-					},
+			"item": [
+				{
+					"name": "SETTLE  settlement",
+					"item": [
 						{
-							"name": "Run Quote & Transfers",
-							"item": [{
-								"name": "Get Existing Open Window",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "06ca836d-99c7-49c7-844e-fe68090e14a4",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"pm.test(\"State should be OPEN\", function () {",
-											"    var jsonData = pm.response.json();",
-											"    pm.expect(jsonData[0].state).to.eql('OPEN');",
-											"    pm.environment.set(\"openWindowID\", jsonData[0].settlementWindowId);",
-											"    console.log('openWindowID',pm.environment.get(\"openWindowID\"));",
-											"});",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"auth": {
-										"type": "bearer",
-										"bearer": [{
-											"key": "token",
-											"value": "{{BEARER_TOKEN}}",
-											"type": "string"
-										}]
-									},
-									"method": "GET",
-									"header": [{
-										"key": "FSPIOP-Source",
-										"value": "payerfsp",
-										"type": "text"
-									},
-										{
-											"key": "Content-Type",
-											"value": "application/json",
-											"type": "text"
-										}
-									],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlementWindows?state=OPEN",
-										"host": [
-											"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-										],
-										"path": [
-											"settlementWindows"
-										],
-										"query": [{
-											"key": "state",
-											"value": "OPEN"
-										}]
-									}
-								},
-								"response": []
-							},
+							"name": "Setup Settlement",
+							"item": [
 								{
-									"name": "Close Existing Window",
-									"event": [{
-										"listen": "test",
-										"script": {
-											"id": "5b16f7ed-2212-419d-a43b-e2b38cf2b718",
-											"exec": [
-												"pm.test(\"Status code is 200\", function () {",
-												"    pm.response.to.have.status(200);",
-												"});",
-												"",
-												"pm.test(\"New window State should be OPEN\", function () {",
-												"    console.log(pm.response.json());",
-												"    pm.expect(pm.response.json().state).to.eql('OPEN');",
-												"    pm.environment.set(\"newOpenWindowID\", pm.response.json().settlementWindowId);",
-												"    pm.environment.set(\"closedWindowID\",  pm.environment.get(\"openWindowID\"));",
-												"    console.log('newOpenWindowID',pm.environment.get(\"newOpenWindowID\"));",
-												"    console.log('closedWindowID',pm.environment.get(\"closedWindowID\"));",
-												"});"
-											],
-											"type": "text/javascript"
-										}
-									}],
-									"request": {
-										"method": "POST",
-										"header": [{
-											"key": "Content-Type",
-											"value": "application/json"
-										}],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"state\": \"CLOSED\",\n  \"reason\": \"string\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlementWindows/{{openWindowID}}",
-											"host": [
-												"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-											],
-											"path": [
-												"settlementWindows",
-												"{{openWindowID}}"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Quote 1 (testfsp1 to testfsp2)",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-											"exec": [
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.variables.set('quoteId', generatedUUID);",
-												"   generatedUUID = uuid.v4();",
-												"   pm.environment.set('transactionId', generatedUUID);",
-												"",
-												"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-												""
-											],
-											"type": "text/javascript"
-										}
-									},
+									"name": "Store Settlement&Position Account Balances Before Transfers",
+									"item": [
 										{
-											"listen": "test",
-											"script": {
-												"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp1/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-													"      if(response.responseSize !== 0) {",
-													"          console.log(response.json());",
-													"       pm.test(\"Response ilpPacket is not undefined\", function () {",
-													"           pm.expect(response.json().ilpPacket).not.equal(undefined);",
-													"           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
-													"       });",
-													"       ",
-													"       pm.test(\"Response condition is not undefined\", function () {",
-													"           pm.expect(response.json().condition).not.equal(undefined);",
-													"           pm.environment.set(\"condition\", response.json().condition);",
-													"       });",
-													"      } else {",
-													"          pm.test(\"Quote FAILED\", function () {",
-													"            throw new Error('Did not receive response');",
-													"           });",
-													"",
-													"      }",
-													"       ",
-													"   });",
-													"}, 2000)",
-													"",
-													"",
-													"",
-													""
+											"name": "testfsp1 balances",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "22c316ff-8ffd-4e54-b450-d12deb6e40b0",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"for (var i in jsonData){",
+															"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp1SettleAccountBalanceBeforeTransfer\", jsonData[i].value);",
+															"    }",
+															"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp1PositionAccountBalanceBeforeTransfer\", jsonData[i].value);",
+															"    }",
+															"}",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "GET",
+												"header": [
+													{
+														"key": "FSPIOP-Source",
+														"value": "payerfsp",
+														"type": "text"
+													}
 												],
-												"type": "text/javascript"
-											}
+												"url": {
+													"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
+													"host": [
+														"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+													],
+													"path": [
+														"participants",
+														"testfsp1",
+														"accounts"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "testfsp2 balances",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"for (var i in jsonData){",
+															"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp2SettleAccountBalanceBeforeTransfer\", jsonData[i].value);",
+															"    }",
+															"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp2PositionAccountBalanceBeforeTransfer\", jsonData[i].value);",
+															"    }",
+															"}",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "GET",
+												"header": [
+													{
+														"key": "FSPIOP-Source",
+														"value": "payerfsp",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp2/accounts",
+													"host": [
+														"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+													],
+													"path": [
+														"participants",
+														"testfsp2",
+														"accounts"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "testfsp3 balances",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"for (var i in jsonData){",
+															"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp3SettleAccountBalanceBeforeTransfer\", jsonData[i].value);",
+															"    }",
+															"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp3PositionAccountBalanceBeforeTransfer\", jsonData[i].value);",
+															"    }",
+															"}",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "GET",
+												"header": [
+													{
+														"key": "FSPIOP-Source",
+														"value": "payerfsp",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp3/accounts",
+													"host": [
+														"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+													],
+													"path": [
+														"participants",
+														"testfsp3",
+														"accounts"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "testfsp4 balances",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"for (var i in jsonData){",
+															"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp4SettleAccountBalanceBeforeTransfer\", jsonData[i].value);",
+															"    }",
+															"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp4PositionAccountBalanceBeforeTransfer\", jsonData[i].value);",
+															"    }",
+															"}",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "GET",
+												"header": [
+													{
+														"key": "FSPIOP-Source",
+														"value": "payerfsp",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp4/accounts",
+													"host": [
+														"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+													],
+													"path": [
+														"participants",
+														"testfsp4",
+														"accounts"
+													]
+												}
+											},
+											"response": []
 										}
 									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP1_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.quotes+json"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.quotes+json;version=1.0"
-											},
-											{
-												"key": "Date",
-												"value": "{{dateHeader}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp1"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp2"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp1\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp2\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"60\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
-											"host": [
-												"{{HOST_QUOTING_SERVICE}}"
-											],
-											"path": [
-												"quotes"
-											]
-										}
-									},
-									"response": []
+									"_postman_isSubFolder": true
 								},
 								{
-									"name": "Send Transfer 1 ( testfsp1 to testfsp2 )",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-											"exec": [
-												"var uuid = require('uuid');",
-												"var generatedUUID = uuid.v4();",
-												"pm.environment.set('transfer_ID', generatedUUID);",
-												"",
-												"pm.environment.set('transferDate', (new Date()).toUTCString());",
-												"",
-												"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
-											],
-											"type": "text/javascript"
-										}
-									},
+									"name": "Run Quote & Transfers",
+									"item": [
 										{
-											"listen": "test",
-											"script": {
-												"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"// pm.test(\"Check that Content-Type is present\", function () {",
-													"//     pm.response.to.have.header(\"Content-Type\");",
-													"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
-													"// });",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp1/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-													"          if(response.responseSize !== 0) {",
-													"              var jsonData = response.json();",
-													"              pm.test(\"Response data does not have transferId\", function () {",
-													"               pm.expect(jsonData.transferId).to.eql(undefined);",
-													"              });",
-													"              pm.test(\"Response status is COMMITTED\", function () {",
-													"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-													"              });",
-													"          } else {",
-													"              pm.test(\"Transfer FAILED\", function () {",
-													"                throw new Error('Did not receive response');",
-													"              });",
-													"",
-													"          }",
-													"   });",
-													"}, 2000)",
-													"",
-													"",
-													""
+											"name": "Get Existing Open Window",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "06ca836d-99c7-49c7-844e-fe68090e14a4",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"State should be OPEN\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    pm.expect(jsonData[0].state).to.eql('OPEN');",
+															"    pm.environment.set(\"openWindowID\", jsonData[0].settlementWindowId);",
+															"    console.log('openWindowID',pm.environment.get(\"openWindowID\"));",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "GET",
+												"header": [
+													{
+														"key": "FSPIOP-Source",
+														"value": "payerfsp",
+														"type": "text"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/json",
+														"type": "text"
+													}
 												],
-												"type": "text/javascript"
-											}
+												"url": {
+													"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlementWindows?state=OPEN",
+													"host": [
+														"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+													],
+													"path": [
+														"settlementWindows"
+													],
+													"query": [
+														{
+															"key": "state",
+															"value": "OPEN"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Close Existing Window",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "5b16f7ed-2212-419d-a43b-e2b38cf2b718",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"New window State should be OPEN\", function () {",
+															"    console.log(pm.response.json());",
+															"    pm.expect(pm.response.json().state).to.eql('OPEN');",
+															"    pm.environment.set(\"newOpenWindowID\", pm.response.json().settlementWindowId);",
+															"    pm.environment.set(\"closedWindowID\",  pm.environment.get(\"openWindowID\"));",
+															"    console.log('newOpenWindowID',pm.environment.get(\"newOpenWindowID\"));",
+															"    console.log('closedWindowID',pm.environment.get(\"closedWindowID\"));",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"state\": \"CLOSED\",\n  \"reason\": \"string\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlementWindows/{{openWindowID}}",
+													"host": [
+														"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+													],
+													"path": [
+														"settlementWindows",
+														"{{openWindowID}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Quote 1 (testfsp1 to testfsp2)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+														"exec": [
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.variables.set('quoteId', generatedUUID);",
+															"   generatedUUID = uuid.v4();",
+															"   pm.environment.set('transactionId', generatedUUID);",
+															"",
+															"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP1_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.quotes+json"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.quotes+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp1"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp2"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp1\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp2\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"60\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+													"host": [
+														"{{HOST_QUOTING_SERVICE}}"
+													],
+													"path": [
+														"quotes"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Transfer 1 ( testfsp1 to testfsp2 )",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+														"exec": [
+															"var uuid = require('uuid');",
+															"var generatedUUID = uuid.v4();",
+															"pm.environment.set('transfer_ID', generatedUUID);",
+															"",
+															"pm.environment.set('transferDate', (new Date()).toUTCString());",
+															"",
+															"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.test(\"Check that Content-Type is present\", function () {",
+															"//     pm.response.to.have.header(\"Content-Type\");",
+															"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
+															"// });",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp1/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"          if(response.responseSize !== 0) {",
+															"              var jsonData = response.json();",
+															"              pm.test(\"Response data does not have transferId\", function () {",
+															"               pm.expect(jsonData.transferId).to.eql(undefined);",
+															"              });",
+															"              pm.test(\"Response status is COMMITTED\", function () {",
+															"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+															"              });",
+															"          } else {",
+															"              pm.test(\"Transfer FAILED\", function () {",
+															"                throw new Error('Did not receive response');",
+															"              });",
+															"",
+															"          }",
+															"   });",
+															"}, 2000)",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP1_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Date",
+														"value": "{{transferDate}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp1"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp2"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp1\",\n  \"payeeFsp\": \"testfsp2\",\n  \"amount\": {\n    \"amount\": \"60\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Quote 2 (testfsp1 to testfsp4)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+														"exec": [
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.variables.set('quoteId', generatedUUID);",
+															"   generatedUUID = uuid.v4();",
+															"   pm.environment.set('transactionId', generatedUUID);",
+															"",
+															"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
+															"",
+															"// setTimeout(function () {",
+															"//   pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp1/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
+															"//       if(response.responseSize !== 0) {",
+															"//           console.log(response.json());",
+															"//       pm.test(\"Response ilpPacket is not undefined\", function () {",
+															"//           pm.expect(response.json().ilpPacket).not.equal(undefined);",
+															"//           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
+															"//       });",
+															"       ",
+															"//       pm.test(\"Response condition is not undefined\", function () {",
+															"//           pm.expect(response.json().condition).not.equal(undefined);",
+															"//           pm.environment.set(\"condition\", response.json().condition);",
+															"//       });",
+															"//       } else {",
+															"//           pm.test(\"Quote FAILED\", function () {",
+															"//             throw new Error('Did not receive response');",
+															"//           });",
+															"",
+															"//       }",
+															"       ",
+															"//   });",
+															"// }, 2000)",
+															"",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP1_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.quotes+json"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.quotes+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp1"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp4"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp1\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp4\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"55\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+													"host": [
+														"{{HOST_QUOTING_SERVICE}}"
+													],
+													"path": [
+														"quotes"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Transfer 2 (testfsp1 to testfsp4)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+														"exec": [
+															"var uuid = require('uuid');",
+															"var generatedUUID = uuid.v4();",
+															"pm.environment.set('transfer_ID', generatedUUID);",
+															"",
+															"pm.environment.set('transferDate', (new Date()).toUTCString());",
+															"",
+															"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','true')",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp1/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"          if(response.responseSize !== 0) {",
+															"              var jsonData = response.json();",
+															"              pm.test(\"Response data does not have transferId\", function () {",
+															"               pm.expect(jsonData.transferId).to.eql(undefined);",
+															"             });",
+															"              pm.test(\"Response status is COMMITTED\", function () {",
+															"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+															"              });",
+															"          } else {",
+															"              pm.test(\"Transfer FAILED\", function () {",
+															"                throw new Error('Did not receive response');",
+															"              });",
+															"",
+															"          }",
+															"   });",
+															"}, 2000)"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP1_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Date",
+														"value": "{{transferDate}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp1"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp4"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp1\",\n  \"payeeFsp\": \"testfsp4\",\n  \"amount\": {\n    \"amount\": \"55\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Quote 3 (testfsp3 to testfsp1)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+														"exec": [
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.variables.set('quoteId', generatedUUID);",
+															"   generatedUUID = uuid.v4();",
+															"   pm.environment.set('transactionId', generatedUUID);",
+															"",
+															"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
+															"",
+															"// setTimeout(function () {",
+															"//   pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp3/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
+															"//       if(response.responseSize !== 0) {",
+															"//           console.log(response.json());",
+															"//       pm.test(\"Response ilpPacket is not undefined\", function () {",
+															"//           pm.expect(response.json().ilpPacket).not.equal(undefined);",
+															"//           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
+															"//       });",
+															"       ",
+															"//       pm.test(\"Response condition is not undefined\", function () {",
+															"//           pm.expect(response.json().condition).not.equal(undefined);",
+															"//           pm.environment.set(\"condition\", response.json().condition);",
+															"//       });",
+															"//       } else {",
+															"//           pm.test(\"Quote FAILED\", function () {",
+															"//             throw new Error('Did not receive response');",
+															"//           });",
+															"",
+															"//       }",
+															"       ",
+															"//   });",
+															"// }, 2000)",
+															"",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP3_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.quotes+json"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.quotes+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp3"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp1"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp3\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp1\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"35\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+													"host": [
+														"{{HOST_QUOTING_SERVICE}}"
+													],
+													"path": [
+														"quotes"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Transfer 3 (testfsp3 to testfsp1)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+														"exec": [
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.environment.set('transfer_ID', generatedUUID);",
+															"} else {",
+															"    pm.environment.set('transfer_ID', pm.environment.get('transactionId'));",
+															"}",
+															"",
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+															"   pm.environment.set('transferDate', (new Date()).toUTCString());",
+															"}",
+															"",
+															"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 60000))"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.test(\"Check that Content-Type is present\", function () {",
+															"//     pm.response.to.have.header(\"Content-Type\");",
+															"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
+															"// });",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp3/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"          if(response.responseSize !== 0) {",
+															"              var jsonData = response.json();",
+															"              pm.test(\"Response data does not have transferId\", function () {",
+															"               pm.expect(jsonData.transferId).to.eql(undefined);",
+															"             });",
+															"              pm.test(\"Response status is COMMITTED\", function () {",
+															"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+															"              });",
+															"          } else {",
+															"              pm.test(\"Transfer FAILED\", function () {",
+															"                throw new Error('Did not receive response');",
+															"              });",
+															"",
+															"          }",
+															"   });",
+															"}, 2000)",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP3_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Date",
+														"value": "{{transferDate}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp3"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp1"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp3\",\n  \"payeeFsp\": \"testfsp1\",\n  \"amount\": {\n    \"amount\": \"35\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Quote 4 (testfsp2 to testfsp3)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+														"exec": [
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.variables.set('quoteId', generatedUUID);",
+															"   generatedUUID = uuid.v4();",
+															"   pm.environment.set('transactionId', generatedUUID);",
+															"",
+															"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
+															"",
+															"// setTimeout(function () {",
+															"//   pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp2/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
+															"//       if(response.responseSize !== 0) {",
+															"//           console.log(response.json());",
+															"//       pm.test(\"Response ilpPacket is not undefined\", function () {",
+															"//           pm.expect(response.json().ilpPacket).not.equal(undefined);",
+															"//           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
+															"//       });",
+															"       ",
+															"//       pm.test(\"Response condition is not undefined\", function () {",
+															"//           pm.expect(response.json().condition).not.equal(undefined);",
+															"//           pm.environment.set(\"condition\", response.json().condition);",
+															"//       });",
+															"//       } else {",
+															"//           pm.test(\"Quote FAILED\", function () {",
+															"//             throw new Error('Did not receive response');",
+															"//           });",
+															"",
+															"//       }",
+															"       ",
+															"//   });",
+															"// }, 2000)",
+															"",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP2_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.quotes+json"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.quotes+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp2"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp3"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp2\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp3\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"20\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+													"host": [
+														"{{HOST_QUOTING_SERVICE}}"
+													],
+													"path": [
+														"quotes"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Transfer 4 (testfsp2 to testfsp3)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+														"exec": [
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.environment.set('transfer_ID', generatedUUID);",
+															"} else {",
+															"    pm.environment.set('transfer_ID', pm.environment.get('transactionId'));",
+															"}",
+															"",
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+															"   pm.environment.set('transferDate', (new Date()).toUTCString());",
+															"}",
+															"",
+															"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.test(\"Check that Content-Type is present\", function () {",
+															"//     pm.response.to.have.header(\"Content-Type\");",
+															"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
+															"// });",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp2/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"          if(response.responseSize !== 0) {",
+															"              var jsonData = response.json();",
+															"              pm.test(\"Response data does not have transferId\", function () {",
+															"               pm.expect(jsonData.transferId).to.eql(undefined);",
+															"             });",
+															"              pm.test(\"Response status is COMMITTED\", function () {",
+															"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+															"              });",
+															"          } else {",
+															"              pm.test(\"Transfer FAILED\", function () {",
+															"                throw new Error('Did not receive response');",
+															"              });",
+															"",
+															"          }",
+															"   });",
+															"}, 2000)",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP2_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Date",
+														"value": "{{transferDate}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp2"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp3"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp2\",\n  \"payeeFsp\": \"testfsp3\",\n  \"amount\": {\n    \"amount\": \"20\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Quote 5 (testfsp4 to testfsp2)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+														"exec": [
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.variables.set('quoteId', generatedUUID);",
+															"   generatedUUID = uuid.v4();",
+															"   pm.environment.set('transactionId', generatedUUID);",
+															"",
+															"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
+															"",
+															"// setTimeout(function () {",
+															"//   pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp4/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
+															"//       if(response.responseSize !== 0) {",
+															"//           console.log(response.json());",
+															"//       pm.test(\"Response ilpPacket is not undefined\", function () {",
+															"//           pm.expect(response.json().ilpPacket).not.equal(undefined);",
+															"//           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
+															"//       });",
+															"       ",
+															"//       pm.test(\"Response condition is not undefined\", function () {",
+															"//           pm.expect(response.json().condition).not.equal(undefined);",
+															"//           pm.environment.set(\"condition\", response.json().condition);",
+															"//       });",
+															"//       } else {",
+															"//           pm.test(\"Quote FAILED\", function () {",
+															"//             throw new Error('Did not receive response');",
+															"//           });",
+															"",
+															"//       }",
+															"       ",
+															"//   });",
+															"// }, 2000)",
+															"",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP4_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.quotes+json"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.quotes+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp4"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp2"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp4\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp2\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"35\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+													"host": [
+														"{{HOST_QUOTING_SERVICE}}"
+													],
+													"path": [
+														"quotes"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Transfer 5 (testfsp4 to testfsp2)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+														"exec": [
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.environment.set('transfer_ID', generatedUUID);",
+															"} else {",
+															"    pm.environment.set('transfer_ID', pm.environment.get('transactionId'));",
+															"}",
+															"",
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+															"   pm.environment.set('transferDate', (new Date()).toUTCString());",
+															"}",
+															"",
+															"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.test(\"Check that Content-Type is present\", function () {",
+															"//     pm.response.to.have.header(\"Content-Type\");",
+															"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
+															"// });",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp4/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"          if(response.responseSize !== 0) {",
+															"              var jsonData = response.json();",
+															"              pm.test(\"Response data does not have transferId\", function () {",
+															"               pm.expect(jsonData.transferId).to.eql(undefined);",
+															"             });",
+															"              pm.test(\"Response status is COMMITTED\", function () {",
+															"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+															"              });",
+															"          } else {",
+															"              pm.test(\"Transfer FAILED\", function () {",
+															"                throw new Error('Did not receive response');",
+															"              });",
+															"",
+															"          }",
+															"   });",
+															"}, 2000)",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP4_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Date",
+														"value": "{{transferDate}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp4"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp2"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp4\",\n  \"payeeFsp\": \"testfsp2\",\n  \"amount\": {\n    \"amount\": \"35\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Quote 6 (testfsp4 to testfsp3)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+														"exec": [
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.variables.set('quoteId', generatedUUID);",
+															"   generatedUUID = uuid.v4();",
+															"   pm.environment.set('transactionId', generatedUUID);",
+															"",
+															"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// setTimeout(function () {",
+															"//   pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp4/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
+															"//       if(response.responseSize !== 0) {",
+															"//           console.log(response.json());",
+															"//       pm.test(\"Response ilpPacket is not undefined\", function () {",
+															"//           pm.expect(response.json().ilpPacket).not.equal(undefined);",
+															"//           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
+															"//       });",
+															"       ",
+															"//       pm.test(\"Response condition is not undefined\", function () {",
+															"//           pm.expect(response.json().condition).not.equal(undefined);",
+															"//           pm.environment.set(\"condition\", response.json().condition);",
+															"//       });",
+															"//       } else {",
+															"//           pm.test(\"Quote FAILED\", function () {",
+															"//             throw new Error('Did not receive response');",
+															"//           });",
+															"           ",
+															"//       }",
+															"       ",
+															"//   });",
+															"// }, 2000)",
+															"",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP4_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.quotes+json"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.quotes+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp4"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp3"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp4\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp3\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"25\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+													"host": [
+														"{{HOST_QUOTING_SERVICE}}"
+													],
+													"path": [
+														"quotes"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Transfer 6 (testfsp4 to testfsp3)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+														"exec": [
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.environment.set('transfer_ID', generatedUUID);",
+															"} else {",
+															"    pm.environment.set('transfer_ID', pm.environment.get('transactionId'));",
+															"}",
+															"",
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+															"   pm.environment.set('transferDate', (new Date()).toUTCString());",
+															"}",
+															"",
+															"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.test(\"Check that Content-Type is present\", function () {",
+															"//     pm.response.to.have.header(\"Content-Type\");",
+															"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
+															"// });",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp4/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"          if(response.responseSize !== 0) {",
+															"              var jsonData = response.json();",
+															"              pm.test(\"Response data does not have transferId\", function () {",
+															"               pm.expect(jsonData.transferId).to.eql(undefined);",
+															"             });",
+															"              pm.test(\"Response status is COMMITTED\", function () {",
+															"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+															"              });",
+															"          } else {",
+															"              pm.test(\"Transfer FAILED\", function () {",
+															"                throw new Error('Did not receive response');",
+															"              });",
+															"",
+															"          }",
+															"   });",
+															"}, 2000)",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{TESTFSP4_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Date",
+														"value": "{{transferDate}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "testfsp4"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "testfsp3"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp4\",\n  \"payeeFsp\": \"testfsp3\",\n  \"amount\": {\n    \"amount\": \"25\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers"
+													]
+												}
+											},
+											"response": []
 										}
 									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP1_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.transfers+json;version=1"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.transfers+json;version=1"
-											},
-											{
-												"key": "Date",
-												"value": "{{transferDate}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp1"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp2"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp1\",\n  \"payeeFsp\": \"testfsp2\",\n  \"amount\": {\n    \"amount\": \"60\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-											"host": [
-												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-											],
-											"path": [
-												"transfers"
-											]
-										}
-									},
-									"response": []
+									"_postman_isSubFolder": true
 								},
 								{
-									"name": "Send Quote 2 (testfsp1 to testfsp4)",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-											"exec": [
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.variables.set('quoteId', generatedUUID);",
-												"   generatedUUID = uuid.v4();",
-												"   pm.environment.set('transactionId', generatedUUID);",
-												"",
-												"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-												""
-											],
-											"type": "text/javascript"
-										}
-									},
+									"name": "Create Settlement",
+									"item": [
 										{
-											"listen": "test",
-											"script": {
-												"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp1/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-													"      if(response.responseSize !== 0) {",
-													"          console.log(response.json());",
-													"       pm.test(\"Response ilpPacket is not undefined\", function () {",
-													"           pm.expect(response.json().ilpPacket).not.equal(undefined);",
-													"           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
-													"       });",
-													"       ",
-													"       pm.test(\"Response condition is not undefined\", function () {",
-													"           pm.expect(response.json().condition).not.equal(undefined);",
-													"           pm.environment.set(\"condition\", response.json().condition);",
-													"       });",
-													"      } else {",
-													"          pm.test(\"Quote FAILED\", function () {",
-													"            throw new Error('Did not receive response');",
-													"           });",
-													"",
-													"      }",
-													"       ",
-													"   });",
-													"}, 2000)",
-													"",
-													"",
-													"",
-													""
+											"name": "Get Existing Open Window",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "06ca836d-99c7-49c7-844e-fe68090e14a4",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"State should be OPEN\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    pm.expect(jsonData[0].state).to.eql('OPEN');",
+															"    pm.environment.set(\"openWindowID\", jsonData[0].settlementWindowId);",
+															"    console.log('openWindowID',pm.environment.get(\"openWindowID\"));",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "GET",
+												"header": [
+													{
+														"key": "FSPIOP-Source",
+														"value": "payerfsp",
+														"type": "text"
+													}
 												],
-												"type": "text/javascript"
-											}
+												"url": {
+													"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlementWindows?state=OPEN",
+													"host": [
+														"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+													],
+													"path": [
+														"settlementWindows"
+													],
+													"query": [
+														{
+															"key": "state",
+															"value": "OPEN"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Close Existing Window",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "5b16f7ed-2212-419d-a43b-e2b38cf2b718",
+														"type": "text/javascript",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"New window State should be OPEN\", function () {",
+															"    console.log(pm.response.json());",
+															"    pm.expect(pm.response.json().state).to.eql('OPEN');",
+															"    pm.environment.set(\"newOpenWindowID\", pm.response.json().settlementWindowId);",
+															"    pm.environment.set(\"closedWindowID\",  pm.environment.get(\"openWindowID\"));",
+															"    console.log('newOpenWindowID',pm.environment.get(\"newOpenWindowID\"));",
+															"    console.log('closedWindowID',pm.environment.get(\"closedWindowID\"));",
+															"});"
+														]
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"state\": \"CLOSED\",\n  \"reason\": \"string\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlementWindows/{{openWindowID}}",
+													"host": [
+														"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+													],
+													"path": [
+														"settlementWindows",
+														"{{openWindowID}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Create Settlement for Closed Window",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "2fd9c949-c268-4b8a-b924-724a54c9295d",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.environment.set(\"settlementId\", pm.response.json().id);",
+															"var jsonData = pm.response.json();",
+															"    ",
+															"pm.test(\"Settlement State should be PENDING_SETTLEMENT\", function () {",
+															"    pm.expect(jsonData.state).to.eql('PENDING_SETTLEMENT');",
+															"});",
+															"",
+															"pm.test(\"Number of associated windows should be 1\", function () {",
+															"    pm.expect(jsonData.settlementWindows.length).to.eql(1);",
+															"});",
+															"",
+															"pm.test(\"Associated Settlement Window ID should be: \"+pm.environment.get(\"closedWindowID\"), function () {",
+															"    pm.expect(jsonData.settlementWindows[0].id).to.eql(pm.environment.get(\"closedWindowID\"));",
+															"});",
+															"",
+															"pm.test(\"Associated Settlement Window state should be PENDING_SETTLEMENT \", function () {",
+															"    pm.expect(jsonData.settlementWindows[0].state).to.eql('PENDING_SETTLEMENT');",
+															"});",
+															"",
+															"pm.test(\"Associated number of participants should be 4 \", function () {",
+															"    pm.expect(jsonData.participants.length).to.eql(4);",
+															"});",
+															"",
+															"for(var j in jsonData.participants) {",
+															"    for(var k in jsonData.participants[j].accounts) {",
+															"        console.log(jsonData.participants[j].accounts[k].id)",
+															"        if(jsonData.participants[j].accounts[k].id === Number(pm.environment.get(\"payerFspAccountId\"))) {",
+															"            console.log('payerfspNetSettlementAmount:',jsonData.participants[j].accounts[k].netSettlementAmount.amount)",
+															"            pm.environment.set(\"payerfspNetSettlementAmount\",jsonData.participants[j].accounts[k].netSettlementAmount.amount);",
+															"        } else if(jsonData.participants[j].accounts[k].id === Number(pm.environment.get(\"payeeFspAccountId\"))) {",
+															"            console.log('payeefspNetSettlementAmount:',jsonData.participants[j].accounts[k].netSettlementAmount.amount)",
+															"            pm.environment.set(\"payeefspNetSettlementAmount\",jsonData.participants[j].accounts[k].netSettlementAmount.amount);",
+															"        }",
+															"        ",
+															"    }",
+															"}",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"reason\": \"TESTING\",\n  \"settlementWindows\": [\n    {\n      \"id\": {{closedWindowID}}\n    }\n  ]\n}"
+												},
+												"url": {
+													"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements",
+													"host": [
+														"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+													],
+													"path": [
+														"settlements"
+													]
+												}
+											},
+											"response": []
 										}
 									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP1_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.quotes+json"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.quotes+json;version=1.0"
-											},
-											{
-												"key": "Date",
-												"value": "{{dateHeader}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp1"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp4"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp1\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp4\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"55\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
-											"host": [
-												"{{HOST_QUOTING_SERVICE}}"
-											],
-											"path": [
-												"quotes"
-											]
-										}
-									},
-									"response": []
+									"_postman_isSubFolder": true
 								},
 								{
-									"name": "Send Transfer 2 (testfsp1 to testfsp4)",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-											"exec": [
-												"var uuid = require('uuid');",
-												"var generatedUUID = uuid.v4();",
-												"pm.environment.set('transfer_ID', generatedUUID);",
-												"",
-												"pm.environment.set('transferDate', (new Date()).toUTCString());",
-												"",
-												"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
-											],
-											"type": "text/javascript"
-										}
-									},
+									"name": "Store Settlement&Position Account Balances After Transfers",
+									"item": [
 										{
-											"listen": "test",
-											"script": {
-												"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','true')",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp1/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-													"          if(response.responseSize !== 0) {",
-													"              var jsonData = response.json();",
-													"              pm.test(\"Response data does not have transferId\", function () {",
-													"               pm.expect(jsonData.transferId).to.eql(undefined);",
-													"             });",
-													"              pm.test(\"Response status is COMMITTED\", function () {",
-													"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-													"              });",
-													"          } else {",
-													"              pm.test(\"Transfer FAILED\", function () {",
-													"                throw new Error('Did not receive response');",
-													"              });",
-													"",
-													"          }",
-													"   });",
-													"}, 2000)"
+											"name": "testfsp1 balances",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "22c316ff-8ffd-4e54-b450-d12deb6e40b0",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"for (var i in jsonData){",
+															"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp1SettleAccountBalanceAfterTransfer\", jsonData[i].value);",
+															"    }",
+															"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp1PositionAccountBalanceAfterTransfer\", jsonData[i].value);",
+															"    }",
+															"}",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "GET",
+												"header": [
+													{
+														"key": "FSPIOP-Source",
+														"value": "payerfsp",
+														"type": "text"
+													}
 												],
-												"type": "text/javascript"
-											}
+												"url": {
+													"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
+													"host": [
+														"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+													],
+													"path": [
+														"participants",
+														"testfsp1",
+														"accounts"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "testfsp2 balances",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"for (var i in jsonData){",
+															"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp2SettleAccountBalanceAfterTransfer\", jsonData[i].value);",
+															"    }",
+															"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp2PositionAccountBalanceAfterTransfer\", jsonData[i].value);",
+															"    }",
+															"}",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "GET",
+												"header": [
+													{
+														"key": "FSPIOP-Source",
+														"value": "payerfsp",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp2/accounts",
+													"host": [
+														"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+													],
+													"path": [
+														"participants",
+														"testfsp2",
+														"accounts"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "testfsp3 balances",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"for (var i in jsonData){",
+															"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp3SettleAccountBalanceAfterTransfer\", jsonData[i].value);",
+															"    }",
+															"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp3PositionAccountBalanceAfterTransfer\", jsonData[i].value);",
+															"    }",
+															"}",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "GET",
+												"header": [
+													{
+														"key": "FSPIOP-Source",
+														"value": "payerfsp",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp3/accounts",
+													"host": [
+														"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+													],
+													"path": [
+														"participants",
+														"testfsp3",
+														"accounts"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "testfsp4 balances",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"for (var i in jsonData){",
+															"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp4SettleAccountBalanceAfterTransfer\", jsonData[i].value);",
+															"    }",
+															"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+															"        console.log(jsonData[i].value)",
+															"        pm.environment.set(\"testfsp4PositionAccountBalanceAfterTransfer\", jsonData[i].value);",
+															"    }",
+															"}",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "GET",
+												"header": [
+													{
+														"key": "FSPIOP-Source",
+														"value": "payerfsp",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp4/accounts",
+													"host": [
+														"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+													],
+													"path": [
+														"participants",
+														"testfsp4",
+														"accounts"
+													]
+												}
+											},
+											"response": []
 										}
 									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP1_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.transfers+json;version=1"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.transfers+json;version=1"
-											},
-											{
-												"key": "Date",
-												"value": "{{transferDate}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp1"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp4"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp1\",\n  \"payeeFsp\": \"testfsp4\",\n  \"amount\": {\n    \"amount\": \"55\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-											"host": [
-												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-											],
-											"path": [
-												"transfers"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Quote 3 (testfsp3 to testfsp1)",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-											"exec": [
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.variables.set('quoteId', generatedUUID);",
-												"   generatedUUID = uuid.v4();",
-												"   pm.environment.set('transactionId', generatedUUID);",
-												"",
-												"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-												""
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp3/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-													"      if(response.responseSize !== 0) {",
-													"          console.log(response.json());",
-													"       pm.test(\"Response ilpPacket is not undefined\", function () {",
-													"           pm.expect(response.json().ilpPacket).not.equal(undefined);",
-													"           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
-													"       });",
-													"       ",
-													"       pm.test(\"Response condition is not undefined\", function () {",
-													"           pm.expect(response.json().condition).not.equal(undefined);",
-													"           pm.environment.set(\"condition\", response.json().condition);",
-													"       });",
-													"      } else {",
-													"          pm.test(\"Quote FAILED\", function () {",
-													"            throw new Error('Did not receive response');",
-													"           });",
-													"",
-													"      }",
-													"       ",
-													"   });",
-													"}, 2000)",
-													"",
-													"",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP3_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.quotes+json"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.quotes+json;version=1.0"
-											},
-											{
-												"key": "Date",
-												"value": "{{dateHeader}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp3"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp1"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp3\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp1\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"35\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
-											"host": [
-												"{{HOST_QUOTING_SERVICE}}"
-											],
-											"path": [
-												"quotes"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Transfer 3 (testfsp3 to testfsp1)",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-											"exec": [
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.environment.set('transfer_ID', generatedUUID);",
-												"} else {",
-												"    pm.environment.set('transfer_ID', pm.environment.get('transactionId'));",
-												"}",
-												"",
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-												"   pm.environment.set('transferDate', (new Date()).toUTCString());",
-												"}",
-												"",
-												"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 60000))"
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"// pm.test(\"Check that Content-Type is present\", function () {",
-													"//     pm.response.to.have.header(\"Content-Type\");",
-													"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
-													"// });",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp3/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-													"          if(response.responseSize !== 0) {",
-													"              var jsonData = response.json();",
-													"              pm.test(\"Response data does not have transferId\", function () {",
-													"               pm.expect(jsonData.transferId).to.eql(undefined);",
-													"             });",
-													"              pm.test(\"Response status is COMMITTED\", function () {",
-													"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-													"              });",
-													"          } else {",
-													"              pm.test(\"Transfer FAILED\", function () {",
-													"                throw new Error('Did not receive response');",
-													"              });",
-													"",
-													"          }",
-													"   });",
-													"}, 2000)",
-													"",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP3_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.transfers+json;version=1"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.transfers+json;version=1"
-											},
-											{
-												"key": "Date",
-												"value": "{{transferDate}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp3"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp1"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp3\",\n  \"payeeFsp\": \"testfsp1\",\n  \"amount\": {\n    \"amount\": \"35\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-											"host": [
-												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-											],
-											"path": [
-												"transfers"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Quote 4 (testfsp2 to testfsp3)",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-											"exec": [
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.variables.set('quoteId', generatedUUID);",
-												"   generatedUUID = uuid.v4();",
-												"   pm.environment.set('transactionId', generatedUUID);",
-												"",
-												"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-												""
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp2/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-													"      if(response.responseSize !== 0) {",
-													"          console.log(response.json());",
-													"       pm.test(\"Response ilpPacket is not undefined\", function () {",
-													"           pm.expect(response.json().ilpPacket).not.equal(undefined);",
-													"           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
-													"       });",
-													"       ",
-													"       pm.test(\"Response condition is not undefined\", function () {",
-													"           pm.expect(response.json().condition).not.equal(undefined);",
-													"           pm.environment.set(\"condition\", response.json().condition);",
-													"       });",
-													"      } else {",
-													"          pm.test(\"Quote FAILED\", function () {",
-													"            throw new Error('Did not receive response');",
-													"           });",
-													"",
-													"      }",
-													"       ",
-													"   });",
-													"}, 2000)",
-													"",
-													"",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP2_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.quotes+json"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.quotes+json;version=1.0"
-											},
-											{
-												"key": "Date",
-												"value": "{{dateHeader}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp2"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp3"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp2\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp3\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"20\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
-											"host": [
-												"{{HOST_QUOTING_SERVICE}}"
-											],
-											"path": [
-												"quotes"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Transfer 4 (testfsp2 to testfsp3)",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-											"exec": [
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.environment.set('transfer_ID', generatedUUID);",
-												"} else {",
-												"    pm.environment.set('transfer_ID', pm.environment.get('transactionId'));",
-												"}",
-												"",
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-												"   pm.environment.set('transferDate', (new Date()).toUTCString());",
-												"}",
-												"",
-												"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"// pm.test(\"Check that Content-Type is present\", function () {",
-													"//     pm.response.to.have.header(\"Content-Type\");",
-													"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
-													"// });",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp2/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-													"          if(response.responseSize !== 0) {",
-													"              var jsonData = response.json();",
-													"              pm.test(\"Response data does not have transferId\", function () {",
-													"               pm.expect(jsonData.transferId).to.eql(undefined);",
-													"             });",
-													"              pm.test(\"Response status is COMMITTED\", function () {",
-													"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-													"              });",
-													"          } else {",
-													"              pm.test(\"Transfer FAILED\", function () {",
-													"                throw new Error('Did not receive response');",
-													"              });",
-													"",
-													"          }",
-													"   });",
-													"}, 2000)",
-													"",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP2_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.transfers+json;version=1"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.transfers+json;version=1"
-											},
-											{
-												"key": "Date",
-												"value": "{{transferDate}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp2"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp3"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp2\",\n  \"payeeFsp\": \"testfsp3\",\n  \"amount\": {\n    \"amount\": \"20\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-											"host": [
-												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-											],
-											"path": [
-												"transfers"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Quote 5 (testfsp4 to testfsp2)",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-											"exec": [
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.variables.set('quoteId', generatedUUID);",
-												"   generatedUUID = uuid.v4();",
-												"   pm.environment.set('transactionId', generatedUUID);",
-												"",
-												"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-												""
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp4/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-													"      if(response.responseSize !== 0) {",
-													"          console.log(response.json());",
-													"       pm.test(\"Response ilpPacket is not undefined\", function () {",
-													"           pm.expect(response.json().ilpPacket).not.equal(undefined);",
-													"           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
-													"       });",
-													"       ",
-													"       pm.test(\"Response condition is not undefined\", function () {",
-													"           pm.expect(response.json().condition).not.equal(undefined);",
-													"           pm.environment.set(\"condition\", response.json().condition);",
-													"       });",
-													"      } else {",
-													"          pm.test(\"Quote FAILED\", function () {",
-													"            throw new Error('Did not receive response');",
-													"           });",
-													"",
-													"      }",
-													"       ",
-													"   });",
-													"}, 2000)",
-													"",
-													"",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP4_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.quotes+json"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.quotes+json;version=1.0"
-											},
-											{
-												"key": "Date",
-												"value": "{{dateHeader}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp4"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp2"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp4\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp2\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"35\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
-											"host": [
-												"{{HOST_QUOTING_SERVICE}}"
-											],
-											"path": [
-												"quotes"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Transfer 5 (testfsp4 to testfsp2)",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-											"exec": [
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.environment.set('transfer_ID', generatedUUID);",
-												"} else {",
-												"    pm.environment.set('transfer_ID', pm.environment.get('transactionId'));",
-												"}",
-												"",
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-												"   pm.environment.set('transferDate', (new Date()).toUTCString());",
-												"}",
-												"",
-												"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"// pm.test(\"Check that Content-Type is present\", function () {",
-													"//     pm.response.to.have.header(\"Content-Type\");",
-													"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
-													"// });",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp4/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-													"          if(response.responseSize !== 0) {",
-													"              var jsonData = response.json();",
-													"              pm.test(\"Response data does not have transferId\", function () {",
-													"               pm.expect(jsonData.transferId).to.eql(undefined);",
-													"             });",
-													"              pm.test(\"Response status is COMMITTED\", function () {",
-													"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-													"              });",
-													"          } else {",
-													"              pm.test(\"Transfer FAILED\", function () {",
-													"                throw new Error('Did not receive response');",
-													"              });",
-													"",
-													"          }",
-													"   });",
-													"}, 2000)",
-													"",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP4_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.transfers+json;version=1"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.transfers+json;version=1"
-											},
-											{
-												"key": "Date",
-												"value": "{{transferDate}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp4"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp2"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp4\",\n  \"payeeFsp\": \"testfsp2\",\n  \"amount\": {\n    \"amount\": \"35\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-											"host": [
-												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-											],
-											"path": [
-												"transfers"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Quote 6 (testfsp4 to testfsp3)",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-											"exec": [
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.variables.set('quoteId', generatedUUID);",
-												"   generatedUUID = uuid.v4();",
-												"   pm.environment.set('transactionId', generatedUUID);",
-												"",
-												"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-												""
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp4/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-													"      if(response.responseSize !== 0) {",
-													"          console.log(response.json());",
-													"       pm.test(\"Response ilpPacket is not undefined\", function () {",
-													"           pm.expect(response.json().ilpPacket).not.equal(undefined);",
-													"           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
-													"       });",
-													"       ",
-													"       pm.test(\"Response condition is not undefined\", function () {",
-													"           pm.expect(response.json().condition).not.equal(undefined);",
-													"           pm.environment.set(\"condition\", response.json().condition);",
-													"       });",
-													"      } else {",
-													"          pm.test(\"Quote FAILED\", function () {",
-													"            throw new Error('Did not receive response');",
-													"           });",
-													"           ",
-													"      }",
-													"       ",
-													"   });",
-													"}, 2000)",
-													"",
-													"",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP4_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.quotes+json"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.quotes+json;version=1.0"
-											},
-											{
-												"key": "Date",
-												"value": "{{dateHeader}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp4"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp3"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"testfsp4\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"testfsp3\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"25\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
-											"host": [
-												"{{HOST_QUOTING_SERVICE}}"
-											],
-											"path": [
-												"quotes"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Transfer 6 (testfsp4 to testfsp3)",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-											"exec": [
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.environment.set('transfer_ID', generatedUUID);",
-												"} else {",
-												"    pm.environment.set('transfer_ID', pm.environment.get('transactionId'));",
-												"}",
-												"",
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-												"   pm.environment.set('transferDate', (new Date()).toUTCString());",
-												"}",
-												"",
-												"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"// pm.test(\"Check that Content-Type is present\", function () {",
-													"//     pm.response.to.have.header(\"Content-Type\");",
-													"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
-													"// });",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/testfsp4/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-													"          if(response.responseSize !== 0) {",
-													"              var jsonData = response.json();",
-													"              pm.test(\"Response data does not have transferId\", function () {",
-													"               pm.expect(jsonData.transferId).to.eql(undefined);",
-													"             });",
-													"              pm.test(\"Response status is COMMITTED\", function () {",
-													"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-													"              });",
-													"          } else {",
-													"              pm.test(\"Transfer FAILED\", function () {",
-													"                throw new Error('Did not receive response');",
-													"              });",
-													"",
-													"          }",
-													"   });",
-													"}, 2000)",
-													"",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{TESTFSP4_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.transfers+json;version=1"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.transfers+json;version=1"
-											},
-											{
-												"key": "Date",
-												"value": "{{transferDate}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "testfsp4"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "testfsp3"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"testfsp4\",\n  \"payeeFsp\": \"testfsp3\",\n  \"amount\": {\n    \"amount\": \"25\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-											"host": [
-												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-											],
-											"path": [
-												"transfers"
-											]
-										}
-									},
-									"response": []
+									"_postman_isSubFolder": true
 								}
 							],
 							"_postman_isSubFolder": true
 						},
 						{
-							"name": "Create Settlement",
-							"item": [{
-								"name": "Get Existing Open Window",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "06ca836d-99c7-49c7-844e-fe68090e14a4",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"pm.test(\"State should be OPEN\", function () {",
-											"    var jsonData = pm.response.json();",
-											"    pm.expect(jsonData[0].state).to.eql('OPEN');",
-											"    pm.environment.set(\"openWindowID\", jsonData[0].settlementWindowId);",
-											"    console.log('openWindowID',pm.environment.get(\"openWindowID\"));",
-											"});",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"auth": {
-										"type": "bearer",
-										"bearer": [{
-											"key": "token",
-											"value": "{{BEARER_TOKEN}}",
-											"type": "string"
-										}]
-									},
-									"method": "GET",
-									"header": [{
-										"key": "FSPIOP-Source",
-										"value": "payerfsp",
-										"type": "text"
-									}],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlementWindows?state=OPEN",
-										"host": [
-											"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-										],
-										"path": [
-											"settlementWindows"
-										],
-										"query": [{
-											"key": "state",
-											"value": "OPEN"
-										}]
-									}
-								},
-								"response": []
-							},
+							"name": "Prepare Settlement",
+							"item": [
 								{
-									"name": "Close Existing Window",
-									"event": [{
-										"listen": "test",
-										"script": {
-											"id": "5b16f7ed-2212-419d-a43b-e2b38cf2b718",
-											"type": "text/javascript",
-											"exec": [
-												"pm.test(\"Status code is 200\", function () {",
-												"    pm.response.to.have.status(200);",
-												"});",
-												"",
-												"pm.test(\"New window State should be OPEN\", function () {",
-												"    console.log(pm.response.json());",
-												"    pm.expect(pm.response.json().state).to.eql('OPEN');",
-												"    pm.environment.set(\"newOpenWindowID\", pm.response.json().settlementWindowId);",
-												"    pm.environment.set(\"closedWindowID\",  pm.environment.get(\"openWindowID\"));",
-												"    console.log('newOpenWindowID',pm.environment.get(\"newOpenWindowID\"));",
-												"    console.log('closedWindowID',pm.environment.get(\"closedWindowID\"));",
-												"});"
-											]
+									"name": "Prepare Settlement",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "84a1662c-7bc3-4d02-a4c7-ad43d4f4b514",
+												"exec": [
+													"",
+													"var jsonData = pm.response.json();",
+													"for(var j in jsonData.participants) {",
+													"    for(var k in jsonData.participants[j].accounts) {",
+													"        console.log(jsonData.participants[j].accounts[k].id)",
+													"        const participantPutRequest = {",
+													"          url: pm.environment.get(\"HOST_CENTRAL_SETTLEMENT\")+pm.environment.get(\"BASE_CENTRAL_SETTLEMENT\")+'/settlements/'+pm.environment.get(\"settlementId\"),",
+													"          method: 'PUT',",
+													"          header: {",
+													"              \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
+													"              \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+													"              \"Content-Type\": \"application/json\"",
+													"          },",
+													"          body: {",
+													"            mode: 'raw',",
+													"            raw: JSON.stringify(",
+													"                {",
+													"                  \"participants\": [",
+													"                    {",
+													"                      \"id\": jsonData.participants[j].id,",
+													"                      \"accounts\": [",
+													"                        {",
+													"                          \"id\": jsonData.participants[j].accounts[k].id,",
+													"                          \"reason\": \"Transfers recorded for payer\",",
+													"                          \"state\": \"PS_TRANSFERS_RECORDED\"",
+													"                        }",
+													"                      ]",
+													"                    }",
+													"                  ]",
+													"                }",
+													"            )",
+													"          }",
+													"        };",
+													"        pm.sendRequest(participantPutRequest, function (err, response) {",
+													"            console.log(response.json());",
+													"        });",
+													"        ",
+													"    }",
+													"}"
+												],
+												"type": "text/javascript"
+											}
 										}
-									}],
-									"request": {
-										"method": "POST",
-										"header": [{
-											"key": "Content-Type",
-											"value": "application/json"
-										}],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"state\": \"CLOSED\",\n  \"reason\": \"string\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlementWindows/{{openWindowID}}",
-											"host": [
-												"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-											],
-											"path": [
-												"settlementWindows",
-												"{{openWindowID}}"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Create Settlement for Closed Window",
-									"event": [{
-										"listen": "test",
-										"script": {
-											"id": "2fd9c949-c268-4b8a-b924-724a54c9295d",
-											"exec": [
-												"pm.test(\"Status code is 200\", function () {",
-												"    pm.response.to.have.status(200);",
-												"});",
-												"",
-												"pm.environment.set(\"settlementId\", pm.response.json().id);",
-												"var jsonData = pm.response.json();",
-												"    ",
-												"pm.test(\"Settlement State should be PENDING_SETTLEMENT\", function () {",
-												"    pm.expect(jsonData.state).to.eql('PENDING_SETTLEMENT');",
-												"});",
-												"",
-												"pm.test(\"Number of associated windows should be 1\", function () {",
-												"    pm.expect(jsonData.settlementWindows.length).to.eql(1);",
-												"});",
-												"",
-												"pm.test(\"Associated Settlement Window ID should be: \"+pm.environment.get(\"closedWindowID\"), function () {",
-												"    pm.expect(jsonData.settlementWindows[0].id).to.eql(pm.environment.get(\"closedWindowID\"));",
-												"});",
-												"",
-												"pm.test(\"Associated Settlement Window state should be PENDING_SETTLEMENT \", function () {",
-												"    pm.expect(jsonData.settlementWindows[0].state).to.eql('PENDING_SETTLEMENT');",
-												"});",
-												"",
-												"pm.test(\"Associated number of participants should be 4 \", function () {",
-												"    pm.expect(jsonData.participants.length).to.eql(4);",
-												"});",
-												"",
-												"for(var j in jsonData.participants) {",
-												"    for(var k in jsonData.participants[j].accounts) {",
-												"        console.log(jsonData.participants[j].accounts[k].id)",
-												"        if(jsonData.participants[j].accounts[k].id === Number(pm.environment.get(\"payerFspAccountId\"))) {",
-												"            console.log('payerfspNetSettlementAmount:',jsonData.participants[j].accounts[k].netSettlementAmount.amount)",
-												"            pm.environment.set(\"payerfspNetSettlementAmount\",jsonData.participants[j].accounts[k].netSettlementAmount.amount);",
-												"        } else if(jsonData.participants[j].accounts[k].id === Number(pm.environment.get(\"payeeFspAccountId\"))) {",
-												"            console.log('payeefspNetSettlementAmount:',jsonData.participants[j].accounts[k].netSettlementAmount.amount)",
-												"            pm.environment.set(\"payeefspNetSettlementAmount\",jsonData.participants[j].accounts[k].netSettlementAmount.amount);",
-												"        }",
-												"        ",
-												"    }",
-												"}",
-												"",
-												""
-											],
-											"type": "text/javascript"
-										}
-									}],
-									"request": {
-										"method": "POST",
-										"header": [{
-											"key": "Content-Type",
-											"value": "application/json"
-										}],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"reason\": \"TESTING\",\n  \"settlementWindows\": [\n    {\n      \"id\": {{closedWindowID}}\n    }\n  ]\n}"
-										},
-										"url": {
-											"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements",
-											"host": [
-												"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-											],
-											"path": [
-												"settlements"
-											]
-										}
-									},
-									"response": []
-								}
-							],
-							"_postman_isSubFolder": true
-						},
-						{
-							"name": "Store Settlement&Position Account Balances After Transfers",
-							"item": [{
-								"name": "testfsp1 balances",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "22c316ff-8ffd-4e54-b450-d12deb6e40b0",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        console.log(jsonData[i].value)",
-											"        pm.environment.set(\"testfsp1SettleAccountBalanceAfterTransfer\", jsonData[i].value);",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        console.log(jsonData[i].value)",
-											"        pm.environment.set(\"testfsp1PositionAccountBalanceAfterTransfer\", jsonData[i].value);",
-											"    }",
-											"}",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"auth": {
-										"type": "bearer",
-										"bearer": [{
-											"key": "token",
-											"value": "{{BEARER_TOKEN}}",
-											"type": "string"
-										}]
-									},
-									"method": "GET",
-									"header": [{
-										"key": "FSPIOP-Source",
-										"value": "payerfsp",
-										"type": "text"
-									}],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp1",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-								{
-									"name": "testfsp2 balances",
-									"event": [{
-										"listen": "test",
-										"script": {
-											"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
-											"exec": [
-												"pm.test(\"Status code is 200\", function () {",
-												"    pm.response.to.have.status(200);",
-												"});",
-												"",
-												"var jsonData = pm.response.json();",
-												"for (var i in jsonData){",
-												"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-												"        console.log(jsonData[i].value)",
-												"        pm.environment.set(\"testfsp2SettleAccountBalanceAfterTransfer\", jsonData[i].value);",
-												"    }",
-												"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-												"        console.log(jsonData[i].value)",
-												"        pm.environment.set(\"testfsp2PositionAccountBalanceAfterTransfer\", jsonData[i].value);",
-												"    }",
-												"}",
-												"",
-												""
-											],
-											"type": "text/javascript"
-										}
-									}],
+									],
 									"request": {
 										"auth": {
 											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{BEARER_TOKEN}}",
-												"type": "string"
-											}]
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{BEARER_TOKEN}}",
+													"type": "string"
+												}
+											]
 										},
 										"method": "GET",
-										"header": [{
-											"key": "FSPIOP-Source",
-											"value": "payerfsp",
-											"type": "text"
-										}],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
+										"header": [
+											{
+												"key": "FSPIOP-Source",
+												"value": "payerfsp",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
+											"host": [
+												"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+											],
+											"path": [
+												"settlements",
+												"{{settlementId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "check state for participants after prepare",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "1d0f3b99-4ab4-4e9a-8655-30297675b802",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"    ",
+													"pm.test(\"Settlement Id should be: \"+pm.environment.get(\"settlementId\"), function () {",
+													"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"settlementId\"));",
+													"});",
+													"",
+													"pm.test(\"Settlement state should be PS_TRANSFERS_RECORDED\", function () {",
+													"    pm.expect(jsonData.state).to.eql(\"PS_TRANSFERS_RECORDED\");",
+													"});",
+													"",
+													"pm.test(\"Settlement Window ID should be: \"+pm.environment.get(\"closedWindowID\"), function () {",
+													"    pm.expect(jsonData.settlementWindows[0].id).to.eql(pm.environment.get(\"closedWindowID\"));",
+													"});",
+													"",
+													"pm.test(\"Settlement Window State should be PENDING_SETTLEMENT\", function () {",
+													"    pm.expect(jsonData.settlementWindows[0].state).to.eql(\"PENDING_SETTLEMENT\");",
+													"});",
+													"",
+													"for(var j in jsonData.participants) {",
+													"    for(var k in jsonData.participants[j].accounts) {",
+													"        pm.test(`Participant Account ${jsonData.participants[j].accounts[k].id} state is PS_TRANSFERS_RECORDED`, function () {",
+													"            pm.expect(jsonData.participants[j].accounts[k].state).to.eql(\"PS_TRANSFERS_RECORDED\");",
+													"        });",
+													"    }",
+													"}",
+													"",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
+											"host": [
+												"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+											],
+											"path": [
+												"settlements",
+												"{{settlementId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp1 settlement&position accont balance after prepare",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp1SettleAccountBalanceAfterPrepare;",
+													"var testfsp1PositionAccountBalanceAfterPrepare;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp1SettleAccountBalanceAfterPrepare = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp1PositionAccountBalanceAfterPrepare = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp1 settlement account balance before and  after prepare should be the same.\", function () {",
+													"    pm.expect(testfsp1SettleAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp1SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"",
+													"pm.test(\"Testfsp1 position account balance before and  after prepare should be the same.\", function () {",
+													"    pm.expect(testfsp1PositionAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp1PositionAccountBalanceAfterTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp1",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp2 settlement&position accont balance after prepare",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp2SettleAccountBalanceAfterPrepare;",
+													"var testfsp2PositionAccountBalanceAfterPrepare;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp2SettleAccountBalanceAfterPrepare = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp2PositionAccountBalanceAfterPrepare = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp2 settlement account balance before and  after prepare should be the same.\", function () {",
+													"    pm.expect(testfsp2SettleAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp2SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp2 position account balance before and  after prepare should be the same.\", function () {",
+													"    pm.expect(testfsp2PositionAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp2PositionAccountBalanceAfterTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
 										"url": {
 											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp2/accounts",
 											"host": [
@@ -4493,52 +4965,44 @@
 									"response": []
 								},
 								{
-									"name": "testfsp3 balances",
-									"event": [{
-										"listen": "test",
-										"script": {
-											"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
-											"exec": [
-												"pm.test(\"Status code is 200\", function () {",
-												"    pm.response.to.have.status(200);",
-												"});",
-												"",
-												"var jsonData = pm.response.json();",
-												"for (var i in jsonData){",
-												"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-												"        console.log(jsonData[i].value)",
-												"        pm.environment.set(\"testfsp3SettleAccountBalanceAfterTransfer\", jsonData[i].value);",
-												"    }",
-												"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-												"        console.log(jsonData[i].value)",
-												"        pm.environment.set(\"testfsp3PositionAccountBalanceAfterTransfer\", jsonData[i].value);",
-												"    }",
-												"}",
-												"",
-												""
-											],
-											"type": "text/javascript"
+									"name": "testfsp3 settlement&position accont balance after prepare",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp3SettleAccountBalanceAfterPrepare;",
+													"var testfsp3PositionAccountBalanceAfterPrepare;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp3SettleAccountBalanceAfterPrepare = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp3PositionAccountBalanceAfterPrepare = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp3 settlement account balance before and  after reserve should be the same.\", function () {",
+													"    pm.expect(testfsp3SettleAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp3SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp3 position account balance before and  after prepare should be the same.\", function () {",
+													"    pm.expect(testfsp3PositionAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp3PositionAccountBalanceAfterTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
 										}
-									}],
+									],
 									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
 										"method": "GET",
-										"header": [{
-											"key": "FSPIOP-Source",
-											"value": "payerfsp",
-											"type": "text"
-										}],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
+										"header": [],
 										"url": {
 											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp3/accounts",
 											"host": [
@@ -4554,52 +5018,44 @@
 									"response": []
 								},
 								{
-									"name": "testfsp4 balances",
-									"event": [{
-										"listen": "test",
-										"script": {
-											"id": "226979b9-928d-4e9d-85a8-4cf993dd471a",
-											"exec": [
-												"pm.test(\"Status code is 200\", function () {",
-												"    pm.response.to.have.status(200);",
-												"});",
-												"",
-												"var jsonData = pm.response.json();",
-												"for (var i in jsonData){",
-												"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-												"        console.log(jsonData[i].value)",
-												"        pm.environment.set(\"testfsp4SettleAccountBalanceAfterTransfer\", jsonData[i].value);",
-												"    }",
-												"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-												"        console.log(jsonData[i].value)",
-												"        pm.environment.set(\"testfsp4PositionAccountBalanceAfterTransfer\", jsonData[i].value);",
-												"    }",
-												"}",
-												"",
-												""
-											],
-											"type": "text/javascript"
+									"name": "testfsp4 settlement&position accont balance after prepare",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp4SettleAccountBalanceAfterPrepare;",
+													"var testfsp4PositionAccountBalanceAfterPrepare;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp4SettleAccountBalanceAfterPrepare = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp4PositionAccountBalanceAfterPrepare = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp4 settlement account balance before and  after prepare should be the same.\", function () {",
+													"    pm.expect(testfsp4SettleAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp4SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp4 position account balance before and  after prepare should be the same.\", function () {",
+													"    pm.expect(testfsp4PositionAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp4PositionAccountBalanceAfterTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
 										}
-									}],
+									],
 									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
 										"method": "GET",
-										"header": [{
-											"key": "FSPIOP-Source",
-											"value": "payerfsp",
-											"type": "text"
-										}],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
+										"header": [],
 										"url": {
 											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp4/accounts",
 											"host": [
@@ -4616,1549 +5072,1158 @@
 								}
 							],
 							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Reserve Settlement",
+							"item": [
+								{
+									"name": "Reserve Settlement",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "84a1662c-7bc3-4d02-a4c7-ad43d4f4b514",
+												"exec": [
+													"",
+													"var jsonData = pm.response.json();",
+													"for(var j in jsonData.participants) {",
+													"    for(var k in jsonData.participants[j].accounts) {",
+													"        console.log(jsonData.participants[j].accounts[k].id)",
+													"        const participantPutRequest = {",
+													"          url: pm.environment.get(\"HOST_CENTRAL_SETTLEMENT\")+pm.environment.get(\"BASE_CENTRAL_SETTLEMENT\")+'/settlements/'+pm.environment.get(\"settlementId\"),",
+													"          method: 'PUT',",
+													"          header: {",
+													"              \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
+													"              \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+													"              \"Content-Type\": \"application/json\"",
+													"          },",
+													"          body: {",
+													"            mode: 'raw',",
+													"            raw: JSON.stringify(",
+													"                {",
+													"                  \"participants\": [",
+													"                    {",
+													"                      \"id\": jsonData.participants[j].id,",
+													"                      \"accounts\": [",
+													"                        {",
+													"                          \"id\": jsonData.participants[j].accounts[k].id,",
+													"                          \"reason\": \"Transfers reserved\",",
+													"                          \"state\": \"PS_TRANSFERS_RESERVED\"",
+													"                        }",
+													"                      ]",
+													"                    }",
+													"                  ]",
+													"                }",
+													"            )",
+													"          }",
+													"        };",
+													"        pm.sendRequest(participantPutRequest, function (err, response) {",
+													"            console.log(response.json());",
+													"        });",
+													"        ",
+													"    }",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{BEARER_TOKEN}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "FSPIOP-Source",
+												"type": "text",
+												"value": "payerfsp"
+											}
+										],
+										"url": {
+											"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
+											"host": [
+												"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+											],
+											"path": [
+												"settlements",
+												"{{settlementId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "check state for participants after reserve",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "1d0f3b99-4ab4-4e9a-8655-30297675b802",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"    ",
+													"pm.test(\"Settlement Id should be: \"+pm.environment.get(\"settlementId\"), function () {",
+													"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"settlementId\"));",
+													"});",
+													"",
+													"pm.test(\"Settlement state should be PS_TRANSFERS_RESERVED\", function () {",
+													"    pm.expect(jsonData.state).to.eql(\"PS_TRANSFERS_RESERVED\");",
+													"});",
+													"",
+													"pm.test(\"Settlement Window ID should be: \"+pm.environment.get(\"closedWindowID\"), function () {",
+													"    pm.expect(jsonData.settlementWindows[0].id).to.eql(pm.environment.get(\"closedWindowID\"));",
+													"});",
+													"",
+													"pm.test(\"Settlement Window State should be PENDING_SETTLEMENT\", function () {",
+													"    pm.expect(jsonData.settlementWindows[0].state).to.eql(\"PENDING_SETTLEMENT\");",
+													"});",
+													"",
+													"for(var j in jsonData.participants) {",
+													"    for(var k in jsonData.participants[j].accounts) {",
+													"        pm.test(`Participant Account ${jsonData.participants[j].accounts[k].id} state is PS_TRANSFERS_RESERVED`, function () {",
+													"            pm.expect(jsonData.participants[j].accounts[k].state).to.eql(\"PS_TRANSFERS_RESERVED\");",
+													"        });",
+													"    }",
+													"}",
+													"",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
+											"host": [
+												"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+											],
+											"path": [
+												"settlements",
+												"{{settlementId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp1 settlement&position accont balance after reserve",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp1SettleAccountBalanceAfterReserve;",
+													"var testfsp1PositionAccountBalanceAfterReserve;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp1SettleAccountBalanceAfterReserve = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp1PositionAccountBalanceAfterReserve = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp1 settlement account balance before and  after reserve should be the same.\", function () {",
+													"    pm.expect(testfsp1SettleAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp1SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp1 position account balance before and  after reserve should be the same.\", function () {",
+													"    pm.expect(testfsp1PositionAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp1PositionAccountBalanceAfterTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp1",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp2 settlement&position accont balance after reserve",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp2SettleAccountBalanceAfterReserve;",
+													"var testfsp2PositionAccountBalanceAfterReserve;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp2SettleAccountBalanceAfterReserve = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp2PositionAccountBalanceAfterReserve = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp2 settlement account balance before and  after reserve should be the same.\", function () {",
+													"    pm.expect(testfsp2SettleAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp2SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp2 position account balance after reserve gets increased by its net settlement  amount.\", function () {",
+													"    pm.expect(testfsp2PositionAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp2PositionAccountBalanceBeforeTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp2/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp2",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp3 settlement&position accont balance after reserve",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp3SettleAccountBalanceAfterReserve;",
+													"var testfsp3PositionAccountBalanceAfterReserve;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp3SettleAccountBalanceAfterReserve = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp3PositionAccountBalanceAfterReserve = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp3 settlement account balance before and  after reserve should be the same.\", function () {",
+													"    pm.expect(testfsp3SettleAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp3SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"",
+													"pm.test(\"Testfsp3 position account balance after reserve gets increased by its net settlement  amount.\", function () {",
+													"    pm.expect(testfsp3PositionAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp3PositionAccountBalanceBeforeTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp3/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp3",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp4 settlement&position accont balance after reserve",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp4SettleAccountBalanceAfterReserve;",
+													"var testfsp4PositionAccountBalanceAfterReserve;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp4SettleAccountBalanceAfterReserve = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp4PositionAccountBalanceAfterReserve = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp4 settlement account balance before and  after reserve should be the same.\", function () {",
+													"    pm.expect(testfsp4SettleAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp4SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp4 position account balance before and  after reserve should be the same.\", function () {",
+													"    pm.expect(testfsp4PositionAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp4PositionAccountBalanceAfterTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp4/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp4",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Commit Settlement",
+							"item": [
+								{
+									"name": "Commit Settlement",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "84a1662c-7bc3-4d02-a4c7-ad43d4f4b514",
+												"exec": [
+													"",
+													"var jsonData = pm.response.json();",
+													"for(var j in jsonData.participants) {",
+													"    for(var k in jsonData.participants[j].accounts) {",
+													"        console.log(jsonData.participants[j].accounts[k].id)",
+													"        const participantPutRequest = {",
+													"          url: pm.environment.get(\"HOST_CENTRAL_SETTLEMENT\")+pm.environment.get(\"BASE_CENTRAL_SETTLEMENT\")+'/settlements/'+pm.environment.get(\"settlementId\"),",
+													"          method: 'PUT',",
+													"          header: {",
+													"              \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
+													"              \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+													"              \"Content-Type\": \"application/json\"",
+													"          },",
+													"          body: {",
+													"            mode: 'raw',",
+													"            raw: JSON.stringify(",
+													"                {",
+													"                  \"participants\": [",
+													"                    {",
+													"                      \"id\": jsonData.participants[j].id,",
+													"                      \"accounts\": [",
+													"                        {",
+													"                          \"id\": jsonData.participants[j].accounts[k].id,",
+													"                          \"reason\": \"Transfers committed\",",
+													"                          \"state\": \"PS_TRANSFERS_COMMITTED\"",
+													"                        }",
+													"                      ]",
+													"                    }",
+													"                  ]",
+													"                }",
+													"            )",
+													"          }",
+													"        };",
+													"        pm.sendRequest(participantPutRequest, function (err, response) {",
+													"            console.log(response.json());",
+													"        });",
+													"        ",
+													"    }",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{BEARER_TOKEN}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "FSPIOP-Source",
+												"type": "text",
+												"value": "payerfsp"
+											}
+										],
+										"url": {
+											"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
+											"host": [
+												"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+											],
+											"path": [
+												"settlements",
+												"{{settlementId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "check state for participants after commit",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "1d0f3b99-4ab4-4e9a-8655-30297675b802",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"    ",
+													"pm.test(\"Settlement Id should be: \"+pm.environment.get(\"settlementId\"), function () {",
+													"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"settlementId\"));",
+													"});",
+													"",
+													"pm.test(\"Settlement state should be PS_TRANSFERS_COMMITTED\", function () {",
+													"    pm.expect(jsonData.state).to.eql(\"PS_TRANSFERS_COMMITTED\");",
+													"});",
+													"",
+													"pm.test(\"Settlement Window ID should be: \"+pm.environment.get(\"closedWindowID\"), function () {",
+													"    pm.expect(jsonData.settlementWindows[0].id).to.eql(pm.environment.get(\"closedWindowID\"));",
+													"});",
+													"",
+													"pm.test(\"Settlement Window State should be PENDING_SETTLEMENT\", function () {",
+													"    pm.expect(jsonData.settlementWindows[0].state).to.eql(\"PENDING_SETTLEMENT\");",
+													"});",
+													"",
+													"for(var j in jsonData.participants) {",
+													"    for(var k in jsonData.participants[j].accounts) {",
+													"        pm.test(`Participant Account ${jsonData.participants[j].accounts[k].id} state is PS_TRANSFERS_COMMITTED`, function () {",
+													"            pm.expect(jsonData.participants[j].accounts[k].state).to.eql(\"PS_TRANSFERS_COMMITTED\");",
+													"        });",
+													"    }",
+													"}",
+													"",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
+											"host": [
+												"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+											],
+											"path": [
+												"settlements",
+												"{{settlementId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp1 settlement&position accont balance after commit",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp1SettleAccountBalanceAfterCommit;",
+													"var testfsp1PositionAccountBalanceAfterCommit;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp1SettleAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp1PositionAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp1 settlement account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp1SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp1SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp1 position account balance after commit should be reduced by its net settlement amount.\", function () {",
+													"    pm.expect(testfsp1PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp1PositionAccountBalanceBeforeTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp1",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp2 settlement&position accont balance after commit",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp2SettleAccountBalanceAfterCommit;",
+													"var testfsp2PositionAccountBalanceAfterCommit;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp2SettleAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp2PositionAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp2 settlement account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp2SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp2SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp2 position account balance after reserve gets increased by its net settlement  amount.\", function () {",
+													"    pm.expect(testfsp2PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp2PositionAccountBalanceBeforeTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp2/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp2",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp3 settlement&position accont balance after commit",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp3SettleAccountBalanceAfterCommit;",
+													"var testfsp3PositionAccountBalanceAfterCommit;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp3SettleAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp3PositionAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp3 settlement account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp3SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp3SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp3 position account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp3PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp3PositionAccountBalanceBeforeTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp3/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp3",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp4 settlement&position accont balance after commit",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp4SettleAccountBalanceAfterCommit;",
+													"var testfsp4PositionAccountBalanceAfterCommit;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp4SettleAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp4PositionAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp4 settlement account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp4SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp4SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp4 position account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp4PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp4PositionAccountBalanceBeforeTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp4/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp4",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Settle Settlement",
+							"item": [
+								{
+									"name": "Settle Settlement",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "84a1662c-7bc3-4d02-a4c7-ad43d4f4b514",
+												"exec": [
+													"",
+													"var jsonData = pm.response.json();",
+													"for(var j in jsonData.participants) {",
+													"    for(var k in jsonData.participants[j].accounts) {",
+													"        console.log(jsonData.participants[j].accounts[k].id)",
+													"        const participantPutRequest = {",
+													"          url: pm.environment.get(\"HOST_CENTRAL_SETTLEMENT\")+pm.environment.get(\"BASE_CENTRAL_SETTLEMENT\")+'/settlements/'+pm.environment.get(\"settlementId\"),",
+													"          method: 'PUT',",
+													"          header: {",
+													"              \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
+													"              \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
+													"              \"Content-Type\": \"application/json\"",
+													"          },",
+													"          body: {",
+													"            mode: 'raw',",
+													"            raw: JSON.stringify(",
+													"                {",
+													"                  \"participants\": [",
+													"                    {",
+													"                      \"id\": jsonData.participants[j].id,",
+													"                      \"accounts\": [",
+													"                        {",
+													"                          \"id\": jsonData.participants[j].accounts[k].id,",
+													"                          \"reason\": \"Transfers settled for payer\",",
+													"                          \"state\": \"SETTLED\"",
+													"                        }",
+													"                      ]",
+													"                    }",
+													"                  ]",
+													"                }",
+													"            )",
+													"          }",
+													"        };",
+													"        pm.sendRequest(participantPutRequest, function (err, response) {",
+													"            console.log(response.json());",
+													"        });",
+													"        ",
+													"    }",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{BEARER_TOKEN}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "FSPIOP-Source",
+												"type": "text",
+												"value": "payerfsp"
+											}
+										],
+										"url": {
+											"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
+											"host": [
+												"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+											],
+											"path": [
+												"settlements",
+												"{{settlementId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "check state for participants after settle",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "1d0f3b99-4ab4-4e9a-8655-30297675b802",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"    ",
+													"pm.test(\"Settlement Id should be: \"+pm.environment.get(\"settlementId\"), function () {",
+													"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"settlementId\"));",
+													"});",
+													"",
+													"pm.test(\"Settlement state should be SETTLED\", function () {",
+													"    pm.expect(jsonData.state).to.eql(\"SETTLED\");",
+													"});",
+													"",
+													"pm.test(\"Settlement Window ID should be: \"+pm.environment.get(\"closedWindowID\"), function () {",
+													"    pm.expect(jsonData.settlementWindows[0].id).to.eql(pm.environment.get(\"closedWindowID\"));",
+													"});",
+													"",
+													"pm.test(\"Settlement Window State should be SETTLED\", function () {",
+													"    pm.expect(jsonData.settlementWindows[0].state).to.eql(\"SETTLED\");",
+													"});",
+													"",
+													"for(var j in jsonData.participants) {",
+													"    for(var k in jsonData.participants[j].accounts) {",
+													"        pm.test(`Participant Account ${jsonData.participants[j].accounts[k].id} state is SETTLED`, function () {",
+													"            pm.expect(jsonData.participants[j].accounts[k].state).to.eql(\"SETTLED\");",
+													"        });",
+													"    }",
+													"}",
+													"",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{BEARER_TOKEN}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "FSPIOP-Source",
+												"value": "payerfsp",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
+											"host": [
+												"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
+											],
+											"path": [
+												"settlements",
+												"{{settlementId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp1 settlement&position accont balance after settle",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp1SettleAccountBalanceAfterSettle;",
+													"var testfsp1PositionAccountBalanceAfterSettle;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp1SettleAccountBalanceAfterSettle = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp1PositionAccountBalanceAfterSettle = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp1 settlement account balance before and  after settle should be the same.\", function () {",
+													"    pm.expect(testfsp1SettleAccountBalanceAfterSettle).to.eql(pm.environment.get(\"testfsp1SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp1 position account balance before and  after settle should be the same.\", function () {",
+													"    pm.expect(testfsp1PositionAccountBalanceAfterSettle).to.eql(pm.environment.get(\"testfsp1PositionAccountBalanceBeforeTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp1",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp2 settlement&position accont balance after settle",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp2SettleAccountBalanceAfterCommit;",
+													"var testfsp2PositionAccountBalanceAfterCommit;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp2SettleAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp2PositionAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp2 settlement account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp2SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp2SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp2 position account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp2PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp2PositionAccountBalanceBeforeTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp2/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp2",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp3 settlement&position accont balance after settle",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp3SettleAccountBalanceAfterCommit;",
+													"var testfsp3PositionAccountBalanceAfterCommit;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp3SettleAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp3PositionAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp3 settlement account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp3SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp3SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp3 position account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp3PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp3PositionAccountBalanceBeforeTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp3/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp3",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "testfsp4 settlement&position accont balance after settle",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "55a678e6-1992-4024-82cc-046646d63bf7",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"var testfsp4SettleAccountBalanceAfterCommit;",
+													"var testfsp4PositionAccountBalanceAfterCommit;",
+													"for (var i in jsonData){",
+													"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
+													"        testfsp4SettleAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
+													"        testfsp4PositionAccountBalanceAfterCommit = jsonData[i].value",
+													"    }",
+													"}",
+													"",
+													"pm.test(\"Testfsp4 settlement account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp4SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp4SettleAccountBalanceAfterTransfer\"));",
+													"});",
+													"",
+													"pm.test(\"Testfsp4 position account balance before and  after commit should be the same.\", function () {",
+													"    pm.expect(testfsp4PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp4PositionAccountBalanceBeforeTransfer\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp4/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"testfsp4",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "hub account balance check",
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{BEARER_TOKEN}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/hub/accounts",
+											"host": [
+												"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+											],
+											"path": [
+												"participants",
+												"hub",
+												"accounts"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
 						}
 					],
 					"_postman_isSubFolder": true
-				},
-					{
-						"name": "Prepare Settlement",
-						"item": [{
-							"name": "Prepare Settlement",
-							"event": [{
-								"listen": "test",
-								"script": {
-									"id": "84a1662c-7bc3-4d02-a4c7-ad43d4f4b514",
-									"exec": [
-										"",
-										"var jsonData = pm.response.json();",
-										"for(var j in jsonData.participants) {",
-										"    for(var k in jsonData.participants[j].accounts) {",
-										"        console.log(jsonData.participants[j].accounts[k].id)",
-										"        const participantPutRequest = {",
-										"          url: pm.environment.get(\"HOST_CENTRAL_SETTLEMENT\")+pm.environment.get(\"BASE_CENTRAL_SETTLEMENT\")+'/settlements/'+pm.environment.get(\"settlementId\"),",
-										"          method: 'PUT',",
-										"          header: {",
-										"              \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
-										"              \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-										"              \"Content-Type\": \"application/json\"",
-										"          },",
-										"          body: {",
-										"            mode: 'raw',",
-										"            raw: JSON.stringify(",
-										"                {",
-										"                  \"participants\": [",
-										"                    {",
-										"                      \"id\": jsonData.participants[j].id,",
-										"                      \"accounts\": [",
-										"                        {",
-										"                          \"id\": jsonData.participants[j].accounts[k].id,",
-										"                          \"reason\": \"Transfers recorded for payer\",",
-										"                          \"state\": \"PS_TRANSFERS_RECORDED\"",
-										"                        }",
-										"                      ]",
-										"                    }",
-										"                  ]",
-										"                }",
-										"            )",
-										"          }",
-										"        };",
-										"        pm.sendRequest(participantPutRequest, function (err, response) {",
-										"            console.log(response.json());",
-										"        });",
-										"        ",
-										"    }",
-										"}"
-									],
-									"type": "text/javascript"
-								}
-							}],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
-								},
-								"method": "GET",
-								"header": [{
-									"key": "FSPIOP-Source",
-									"value": "payerfsp",
-									"type": "text"
-								}],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
-									"host": [
-										"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-									],
-									"path": [
-										"settlements",
-										"{{settlementId}}"
-									]
-								}
-							},
-							"response": []
-						},
-							{
-								"name": "check state for participants after prepare",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "1d0f3b99-4ab4-4e9a-8655-30297675b802",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"    ",
-											"pm.test(\"Settlement Id should be: \"+pm.environment.get(\"settlementId\"), function () {",
-											"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"settlementId\"));",
-											"});",
-											"",
-											"pm.test(\"Settlement state should be PS_TRANSFERS_RECORDED\", function () {",
-											"    pm.expect(jsonData.state).to.eql(\"PS_TRANSFERS_RECORDED\");",
-											"});",
-											"",
-											"pm.test(\"Settlement Window ID should be: \"+pm.environment.get(\"closedWindowID\"), function () {",
-											"    pm.expect(jsonData.settlementWindows[0].id).to.eql(pm.environment.get(\"closedWindowID\"));",
-											"});",
-											"",
-											"pm.test(\"Settlement Window State should be PENDING_SETTLEMENT\", function () {",
-											"    pm.expect(jsonData.settlementWindows[0].state).to.eql(\"PENDING_SETTLEMENT\");",
-											"});",
-											"",
-											"for(var j in jsonData.participants) {",
-											"    for(var k in jsonData.participants[j].accounts) {",
-											"        pm.test(`Participant Account ${jsonData.participants[j].accounts[k].id} state is PS_TRANSFERS_RECORDED`, function () {",
-											"            pm.expect(jsonData.participants[j].accounts[k].state).to.eql(\"PS_TRANSFERS_RECORDED\");",
-											"        });",
-											"    }",
-											"}",
-											"",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
-										"host": [
-											"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-										],
-										"path": [
-											"settlements",
-											"{{settlementId}}"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp1 settlement&position accont balance after prepare",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp1SettleAccountBalanceAfterPrepare;",
-											"var testfsp1PositionAccountBalanceAfterPrepare;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp1SettleAccountBalanceAfterPrepare = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp1PositionAccountBalanceAfterPrepare = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp1 settlement account balance before and  after prepare should be the same.\", function () {",
-											"    pm.expect(testfsp1SettleAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp1SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"",
-											"pm.test(\"Testfsp1 position account balance before and  after prepare should be the same.\", function () {",
-											"    pm.expect(testfsp1PositionAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp1PositionAccountBalanceAfterTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp1",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp2 settlement&position accont balance after prepare",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp2SettleAccountBalanceAfterPrepare;",
-											"var testfsp2PositionAccountBalanceAfterPrepare;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp2SettleAccountBalanceAfterPrepare = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp2PositionAccountBalanceAfterPrepare = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp2 settlement account balance before and  after prepare should be the same.\", function () {",
-											"    pm.expect(testfsp2SettleAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp2SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp2 position account balance before and  after prepare should be the same.\", function () {",
-											"    pm.expect(testfsp2PositionAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp2PositionAccountBalanceAfterTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp2/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp2",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp3 settlement&position accont balance after prepare",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp3SettleAccountBalanceAfterPrepare;",
-											"var testfsp3PositionAccountBalanceAfterPrepare;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp3SettleAccountBalanceAfterPrepare = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp3PositionAccountBalanceAfterPrepare = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp3 settlement account balance before and  after reserve should be the same.\", function () {",
-											"    pm.expect(testfsp3SettleAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp3SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp3 position account balance before and  after prepare should be the same.\", function () {",
-											"    pm.expect(testfsp3PositionAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp3PositionAccountBalanceAfterTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp3/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp3",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp4 settlement&position accont balance after prepare",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp4SettleAccountBalanceAfterPrepare;",
-											"var testfsp4PositionAccountBalanceAfterPrepare;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp4SettleAccountBalanceAfterPrepare = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp4PositionAccountBalanceAfterPrepare = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp4 settlement account balance before and  after prepare should be the same.\", function () {",
-											"    pm.expect(testfsp4SettleAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp4SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp4 position account balance before and  after prepare should be the same.\", function () {",
-											"    pm.expect(testfsp4PositionAccountBalanceAfterPrepare).to.eql(pm.environment.get(\"testfsp4PositionAccountBalanceAfterTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp4/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp4",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							}
-						],
-						"_postman_isSubFolder": true
-					},
-					{
-						"name": "Reserve Settlement",
-						"item": [{
-							"name": "Reserve Settlement",
-							"event": [{
-								"listen": "test",
-								"script": {
-									"id": "84a1662c-7bc3-4d02-a4c7-ad43d4f4b514",
-									"exec": [
-										"",
-										"var jsonData = pm.response.json();",
-										"for(var j in jsonData.participants) {",
-										"    for(var k in jsonData.participants[j].accounts) {",
-										"        console.log(jsonData.participants[j].accounts[k].id)",
-										"        const participantPutRequest = {",
-										"          url: pm.environment.get(\"HOST_CENTRAL_SETTLEMENT\")+pm.environment.get(\"BASE_CENTRAL_SETTLEMENT\")+'/settlements/'+pm.environment.get(\"settlementId\"),",
-										"          method: 'PUT',",
-										"          header: {",
-										"              \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
-										"              \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-										"              \"Content-Type\": \"application/json\"",
-										"          },",
-										"          body: {",
-										"            mode: 'raw',",
-										"            raw: JSON.stringify(",
-										"                {",
-										"                  \"participants\": [",
-										"                    {",
-										"                      \"id\": jsonData.participants[j].id,",
-										"                      \"accounts\": [",
-										"                        {",
-										"                          \"id\": jsonData.participants[j].accounts[k].id,",
-										"                          \"reason\": \"Transfers reserved\",",
-										"                          \"state\": \"PS_TRANSFERS_RESERVED\"",
-										"                        }",
-										"                      ]",
-										"                    }",
-										"                  ]",
-										"                }",
-										"            )",
-										"          }",
-										"        };",
-										"        pm.sendRequest(participantPutRequest, function (err, response) {",
-										"            console.log(response.json());",
-										"        });",
-										"        ",
-										"    }",
-										"}"
-									],
-									"type": "text/javascript"
-								}
-							}],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
-								},
-								"method": "GET",
-								"header": [{
-									"key": "FSPIOP-Source",
-									"type": "text",
-									"value": "payerfsp"
-								}],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
-									"host": [
-										"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-									],
-									"path": [
-										"settlements",
-										"{{settlementId}}"
-									]
-								}
-							},
-							"response": []
-						},
-							{
-								"name": "check state for participants after reserve",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "1d0f3b99-4ab4-4e9a-8655-30297675b802",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"    ",
-											"pm.test(\"Settlement Id should be: \"+pm.environment.get(\"settlementId\"), function () {",
-											"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"settlementId\"));",
-											"});",
-											"",
-											"pm.test(\"Settlement state should be PS_TRANSFERS_RESERVED\", function () {",
-											"    pm.expect(jsonData.state).to.eql(\"PS_TRANSFERS_RESERVED\");",
-											"});",
-											"",
-											"pm.test(\"Settlement Window ID should be: \"+pm.environment.get(\"closedWindowID\"), function () {",
-											"    pm.expect(jsonData.settlementWindows[0].id).to.eql(pm.environment.get(\"closedWindowID\"));",
-											"});",
-											"",
-											"pm.test(\"Settlement Window State should be PENDING_SETTLEMENT\", function () {",
-											"    pm.expect(jsonData.settlementWindows[0].state).to.eql(\"PENDING_SETTLEMENT\");",
-											"});",
-											"",
-											"for(var j in jsonData.participants) {",
-											"    for(var k in jsonData.participants[j].accounts) {",
-											"        pm.test(`Participant Account ${jsonData.participants[j].accounts[k].id} state is PS_TRANSFERS_RESERVED`, function () {",
-											"            pm.expect(jsonData.participants[j].accounts[k].state).to.eql(\"PS_TRANSFERS_RESERVED\");",
-											"        });",
-											"    }",
-											"}",
-											"",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
-										"host": [
-											"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-										],
-										"path": [
-											"settlements",
-											"{{settlementId}}"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp1 settlement&position accont balance after reserve",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp1SettleAccountBalanceAfterReserve;",
-											"var testfsp1PositionAccountBalanceAfterReserve;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp1SettleAccountBalanceAfterReserve = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp1PositionAccountBalanceAfterReserve = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp1 settlement account balance before and  after reserve should be the same.\", function () {",
-											"    pm.expect(testfsp1SettleAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp1SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp1 position account balance before and  after reserve should be the same.\", function () {",
-											"    pm.expect(testfsp1PositionAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp1PositionAccountBalanceAfterTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp1",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp2 settlement&position accont balance after reserve",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp2SettleAccountBalanceAfterReserve;",
-											"var testfsp2PositionAccountBalanceAfterReserve;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp2SettleAccountBalanceAfterReserve = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp2PositionAccountBalanceAfterReserve = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp2 settlement account balance before and  after reserve should be the same.\", function () {",
-											"    pm.expect(testfsp2SettleAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp2SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp2 position account balance after reserve gets increased by its net settlement  amount.\", function () {",
-											"    pm.expect(testfsp2PositionAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp2PositionAccountBalanceBeforeTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp2/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp2",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp3 settlement&position accont balance after reserve",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp3SettleAccountBalanceAfterReserve;",
-											"var testfsp3PositionAccountBalanceAfterReserve;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp3SettleAccountBalanceAfterReserve = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp3PositionAccountBalanceAfterReserve = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp3 settlement account balance before and  after reserve should be the same.\", function () {",
-											"    pm.expect(testfsp3SettleAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp3SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"",
-											"pm.test(\"Testfsp3 position account balance after reserve gets increased by its net settlement  amount.\", function () {",
-											"    pm.expect(testfsp3PositionAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp3PositionAccountBalanceBeforeTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp3/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp3",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp4 settlement&position accont balance after reserve",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp4SettleAccountBalanceAfterReserve;",
-											"var testfsp4PositionAccountBalanceAfterReserve;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp4SettleAccountBalanceAfterReserve = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp4PositionAccountBalanceAfterReserve = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp4 settlement account balance before and  after reserve should be the same.\", function () {",
-											"    pm.expect(testfsp4SettleAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp4SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp4 position account balance before and  after reserve should be the same.\", function () {",
-											"    pm.expect(testfsp4PositionAccountBalanceAfterReserve).to.eql(pm.environment.get(\"testfsp4PositionAccountBalanceAfterTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp4/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp4",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							}
-						],
-						"_postman_isSubFolder": true
-					},
-					{
-						"name": "Commit Settlement",
-						"item": [{
-							"name": "Commit Settlement",
-							"event": [{
-								"listen": "test",
-								"script": {
-									"id": "84a1662c-7bc3-4d02-a4c7-ad43d4f4b514",
-									"exec": [
-										"",
-										"var jsonData = pm.response.json();",
-										"for(var j in jsonData.participants) {",
-										"    for(var k in jsonData.participants[j].accounts) {",
-										"        console.log(jsonData.participants[j].accounts[k].id)",
-										"        const participantPutRequest = {",
-										"          url: pm.environment.get(\"HOST_CENTRAL_SETTLEMENT\")+pm.environment.get(\"BASE_CENTRAL_SETTLEMENT\")+'/settlements/'+pm.environment.get(\"settlementId\"),",
-										"          method: 'PUT',",
-										"          header: {",
-										"              \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
-										"              \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-										"              \"Content-Type\": \"application/json\"",
-										"          },",
-										"          body: {",
-										"            mode: 'raw',",
-										"            raw: JSON.stringify(",
-										"                {",
-										"                  \"participants\": [",
-										"                    {",
-										"                      \"id\": jsonData.participants[j].id,",
-										"                      \"accounts\": [",
-										"                        {",
-										"                          \"id\": jsonData.participants[j].accounts[k].id,",
-										"                          \"reason\": \"Transfers committed\",",
-										"                          \"state\": \"PS_TRANSFERS_COMMITTED\"",
-										"                        }",
-										"                      ]",
-										"                    }",
-										"                  ]",
-										"                }",
-										"            )",
-										"          }",
-										"        };",
-										"        pm.sendRequest(participantPutRequest, function (err, response) {",
-										"            console.log(response.json());",
-										"        });",
-										"        ",
-										"    }",
-										"}"
-									],
-									"type": "text/javascript"
-								}
-							}],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
-								},
-								"method": "GET",
-								"header": [{
-									"key": "FSPIOP-Source",
-									"type": "text",
-									"value": "payerfsp"
-								}],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
-									"host": [
-										"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-									],
-									"path": [
-										"settlements",
-										"{{settlementId}}"
-									]
-								}
-							},
-							"response": []
-						},
-							{
-								"name": "check state for participants after commit",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "1d0f3b99-4ab4-4e9a-8655-30297675b802",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"    ",
-											"pm.test(\"Settlement Id should be: \"+pm.environment.get(\"settlementId\"), function () {",
-											"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"settlementId\"));",
-											"});",
-											"",
-											"pm.test(\"Settlement state should be PS_TRANSFERS_COMMITTED\", function () {",
-											"    pm.expect(jsonData.state).to.eql(\"PS_TRANSFERS_COMMITTED\");",
-											"});",
-											"",
-											"pm.test(\"Settlement Window ID should be: \"+pm.environment.get(\"closedWindowID\"), function () {",
-											"    pm.expect(jsonData.settlementWindows[0].id).to.eql(pm.environment.get(\"closedWindowID\"));",
-											"});",
-											"",
-											"pm.test(\"Settlement Window State should be PENDING_SETTLEMENT\", function () {",
-											"    pm.expect(jsonData.settlementWindows[0].state).to.eql(\"PENDING_SETTLEMENT\");",
-											"});",
-											"",
-											"for(var j in jsonData.participants) {",
-											"    for(var k in jsonData.participants[j].accounts) {",
-											"        pm.test(`Participant Account ${jsonData.participants[j].accounts[k].id} state is PS_TRANSFERS_COMMITTED`, function () {",
-											"            pm.expect(jsonData.participants[j].accounts[k].state).to.eql(\"PS_TRANSFERS_COMMITTED\");",
-											"        });",
-											"    }",
-											"}",
-											"",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
-										"host": [
-											"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-										],
-										"path": [
-											"settlements",
-											"{{settlementId}}"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp1 settlement&position accont balance after commit",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp1SettleAccountBalanceAfterCommit;",
-											"var testfsp1PositionAccountBalanceAfterCommit;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp1SettleAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp1PositionAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp1 settlement account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp1SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp1SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp1 position account balance after commit should be reduced by its net settlement amount.\", function () {",
-											"    pm.expect(testfsp1PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp1PositionAccountBalanceBeforeTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp1",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp2 settlement&position accont balance after commit",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp2SettleAccountBalanceAfterCommit;",
-											"var testfsp2PositionAccountBalanceAfterCommit;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp2SettleAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp2PositionAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp2 settlement account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp2SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp2SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp2 position account balance after reserve gets increased by its net settlement  amount.\", function () {",
-											"    pm.expect(testfsp2PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp2PositionAccountBalanceBeforeTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp2/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp2",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp3 settlement&position accont balance after commit",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp3SettleAccountBalanceAfterCommit;",
-											"var testfsp3PositionAccountBalanceAfterCommit;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp3SettleAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp3PositionAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp3 settlement account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp3SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp3SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp3 position account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp3PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp3PositionAccountBalanceBeforeTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp3/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp3",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp4 settlement&position accont balance after commit",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp4SettleAccountBalanceAfterCommit;",
-											"var testfsp4PositionAccountBalanceAfterCommit;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp4SettleAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp4PositionAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp4 settlement account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp4SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp4SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp4 position account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp4PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp4PositionAccountBalanceBeforeTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp4/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp4",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							}
-						],
-						"_postman_isSubFolder": true
-					},
-					{
-						"name": "Settle Settlement",
-						"item": [{
-							"name": "Settle Settlement",
-							"event": [{
-								"listen": "test",
-								"script": {
-									"id": "84a1662c-7bc3-4d02-a4c7-ad43d4f4b514",
-									"exec": [
-										"",
-										"var jsonData = pm.response.json();",
-										"for(var j in jsonData.participants) {",
-										"    for(var k in jsonData.participants[j].accounts) {",
-										"        console.log(jsonData.participants[j].accounts[k].id)",
-										"        const participantPutRequest = {",
-										"          url: pm.environment.get(\"HOST_CENTRAL_SETTLEMENT\")+pm.environment.get(\"BASE_CENTRAL_SETTLEMENT\")+'/settlements/'+pm.environment.get(\"settlementId\"),",
-										"          method: 'PUT',",
-										"          header: {",
-										"              \"Authorization\":\"Bearer \"+pm.environment.get(\"HUBOPERATOR_BEARER_TOKEN\"),",
-										"              \"FSPIOP-Source\": pm.environment.get(\"hub_operator\"),",
-										"              \"Content-Type\": \"application/json\"",
-										"          },",
-										"          body: {",
-										"            mode: 'raw',",
-										"            raw: JSON.stringify(",
-										"                {",
-										"                  \"participants\": [",
-										"                    {",
-										"                      \"id\": jsonData.participants[j].id,",
-										"                      \"accounts\": [",
-										"                        {",
-										"                          \"id\": jsonData.participants[j].accounts[k].id,",
-										"                          \"reason\": \"Transfers settled for payer\",",
-										"                          \"state\": \"SETTLED\"",
-										"                        }",
-										"                      ]",
-										"                    }",
-										"                  ]",
-										"                }",
-										"            )",
-										"          }",
-										"        };",
-										"        pm.sendRequest(participantPutRequest, function (err, response) {",
-										"            console.log(response.json());",
-										"        });",
-										"        ",
-										"    }",
-										"}"
-									],
-									"type": "text/javascript"
-								}
-							}],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
-								},
-								"method": "GET",
-								"header": [{
-									"key": "FSPIOP-Source",
-									"type": "text",
-									"value": "payerfsp"
-								}],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
-									"host": [
-										"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-									],
-									"path": [
-										"settlements",
-										"{{settlementId}}"
-									]
-								}
-							},
-							"response": []
-						},
-							{
-								"name": "check state for participants after settle",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "1d0f3b99-4ab4-4e9a-8655-30297675b802",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"    ",
-											"pm.test(\"Settlement Id should be: \"+pm.environment.get(\"settlementId\"), function () {",
-											"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"settlementId\"));",
-											"});",
-											"",
-											"pm.test(\"Settlement state should be SETTLED\", function () {",
-											"    pm.expect(jsonData.state).to.eql(\"SETTLED\");",
-											"});",
-											"",
-											"pm.test(\"Settlement Window ID should be: \"+pm.environment.get(\"closedWindowID\"), function () {",
-											"    pm.expect(jsonData.settlementWindows[0].id).to.eql(pm.environment.get(\"closedWindowID\"));",
-											"});",
-											"",
-											"pm.test(\"Settlement Window State should be SETTLED\", function () {",
-											"    pm.expect(jsonData.settlementWindows[0].state).to.eql(\"SETTLED\");",
-											"});",
-											"",
-											"for(var j in jsonData.participants) {",
-											"    for(var k in jsonData.participants[j].accounts) {",
-											"        pm.test(`Participant Account ${jsonData.participants[j].accounts[k].id} state is SETTLED`, function () {",
-											"            pm.expect(jsonData.participants[j].accounts[k].state).to.eql(\"SETTLED\");",
-											"        });",
-											"    }",
-											"}",
-											"",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"auth": {
-										"type": "bearer",
-										"bearer": [{
-											"key": "token",
-											"value": "{{BEARER_TOKEN}}",
-											"type": "string"
-										}]
-									},
-									"method": "GET",
-									"header": [{
-										"key": "FSPIOP-Source",
-										"value": "payerfsp",
-										"type": "text"
-									}],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}/settlements/{{settlementId}}",
-										"host": [
-											"{{HOST_CENTRAL_SETTLEMENT}}{{BASE_CENTRAL_SETTLEMENT}}"
-										],
-										"path": [
-											"settlements",
-											"{{settlementId}}"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp1 settlement&position accont balance after settle",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp1SettleAccountBalanceAfterSettle;",
-											"var testfsp1PositionAccountBalanceAfterSettle;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp1SettleAccountBalanceAfterSettle = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp1PositionAccountBalanceAfterSettle = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp1 settlement account balance before and  after settle should be the same.\", function () {",
-											"    pm.expect(testfsp1SettleAccountBalanceAfterSettle).to.eql(pm.environment.get(\"testfsp1SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp1 position account balance before and  after settle should be the same.\", function () {",
-											"    pm.expect(testfsp1PositionAccountBalanceAfterSettle).to.eql(pm.environment.get(\"testfsp1PositionAccountBalanceBeforeTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp1/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp1",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp2 settlement&position accont balance after settle",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp2SettleAccountBalanceAfterCommit;",
-											"var testfsp2PositionAccountBalanceAfterCommit;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp2SettleAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp2PositionAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp2 settlement account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp2SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp2SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp2 position account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp2PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp2PositionAccountBalanceBeforeTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp2/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp2",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp3 settlement&position accont balance after settle",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp3SettleAccountBalanceAfterCommit;",
-											"var testfsp3PositionAccountBalanceAfterCommit;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp3SettleAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp3PositionAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp3 settlement account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp3SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp3SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp3 position account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp3PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp3PositionAccountBalanceBeforeTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp3/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp3",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "testfsp4 settlement&position accont balance after settle",
-								"event": [{
-									"listen": "test",
-									"script": {
-										"id": "55a678e6-1992-4024-82cc-046646d63bf7",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"var jsonData = pm.response.json();",
-											"var testfsp4SettleAccountBalanceAfterCommit;",
-											"var testfsp4PositionAccountBalanceAfterCommit;",
-											"for (var i in jsonData){",
-											"    if(jsonData[i].ledgerAccountType === \"SETTLEMENT\") {",
-											"        testfsp4SettleAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"    if(jsonData[i].ledgerAccountType === \"POSITION\") {",
-											"        testfsp4PositionAccountBalanceAfterCommit = jsonData[i].value",
-											"    }",
-											"}",
-											"",
-											"pm.test(\"Testfsp4 settlement account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp4SettleAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp4SettleAccountBalanceAfterTransfer\"));",
-											"});",
-											"",
-											"pm.test(\"Testfsp4 position account balance before and  after commit should be the same.\", function () {",
-											"    pm.expect(testfsp4PositionAccountBalanceAfterCommit).to.eql(pm.environment.get(\"testfsp4PositionAccountBalanceBeforeTransfer\"));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}],
-								"request": {
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/testfsp4/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"testfsp4",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							},
-							{
-								"name": "hub account balance check",
-								"request": {
-									"auth": {
-										"type": "bearer",
-										"bearer": [{
-											"key": "token",
-											"value": "{{BEARER_TOKEN}}",
-											"type": "string"
-										}]
-									},
-									"method": "GET",
-									"header": [],
-									"body": {
-										"mode": "raw",
-										"raw": ""
-									},
-									"url": {
-										"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/hub/accounts",
-										"host": [
-											"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-										],
-										"path": [
-											"participants",
-											"hub",
-											"accounts"
-										]
-									}
-								},
-								"response": []
-							}
-						],
-						"_postman_isSubFolder": true
-					}
-				],
-				"_postman_isSubFolder": true
-			}],
-			"description": "Author: Sridevi Miriyala",
-			"event": [{
-				"listen": "prerequest",
-				"script": {
-					"id": "308e0d73-5af8-4f1a-ae74-8547c7909504",
-					"type": "text/javascript",
-					"exec": [
-						""
-					]
 				}
-			},
+			],
+			"description": "Author: Sridevi Miriyala",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "308e0d73-5af8-4f1a-ae74-8547c7909504",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
 				{
 					"listen": "test",
 					"script": {
@@ -6173,989 +6238,37 @@
 		},
 		{
 			"name": "transfer_negative_scenarios",
-			"item": [{
-				"name": "payee_abort",
-				"item": [{
-					"name": "Store Payerfsp position before prepare",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});",
-								"",
-								"var jsonData = pm.response.json();",
-								"",
-								"pm.environment.set(\"payerfspPositionBeforePrepare\", jsonData[0].value);",
-								"",
-								"",
-								""
-							],
-							"type": "text/javascript"
-						}
-					},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [{
-								"key": "token",
-								"value": "{{BEARER_TOKEN}}",
-								"type": "string"
-							}]
-						},
-						"method": "GET",
-						"header": [{
-							"key": "FSPIOP-Source",
-							"type": "text",
-							"value": "{{payerfsp}}"
-						}],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
-							"host": [
-								"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-							],
-							"path": [
-								"participants",
-								"{{payerfsp}}",
-								"positions"
-							]
-						}
-					},
-					"response": []
-				},
-					{
-						"name": "Store Payeefsp position before prepare",
-						"event": [{
-							"listen": "test",
-							"script": {
-								"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.environment.set(\"payeefspPositionBeforePrepare\", jsonData[0].value);",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "prerequest",
-								"script": {
-									"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
-									"exec": [
-										""
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "GET",
-							"header": [{
-								"key": "FSPIOP-Source",
-								"type": "text",
-								"value": "{{payerfsp}}"
-							}],
-							"body": {
-								"mode": "raw",
-								"raw": ""
-							},
-							"url": {
-								"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payeefsp}}/positions",
-								"host": [
-									"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-								],
-								"path": [
-									"participants",
-									"{{payeefsp}}",
-									"positions"
-								]
-							}
-						},
-						"response": []
-					},
-					{
-						"name": "Send Prepare",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-								"exec": [
-									"",
-									"var uuid = require('uuid');",
-									"var generatedUUID = uuid.v4();",
-									"pm.environment.set('transfer_ID', generatedUUID);",
-									"pm.environment.set('transferDate', (new Date()).toUTCString());",
-									"",
-									"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 600000))"
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
-									"exec": [
-										"pm.test(\"Status code is 202\", function () {",
-										"    pm.response.to.have.status(202);",
-										"});",
-										"",
-										"",
-										"",
-										"",
-										""
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "POST",
-							"header": [{
-								"key": "Accept",
-								"value": "application/vnd.interoperability.transfers+json;version=1"
-							},
-								{
-									"key": "Content-Type",
-									"value": "application/vnd.interoperability.transfers+json;version=1"
-								},
-								{
-									"key": "Date",
-									"value": "{{dateHeader}}"
-								},
-								{
-									"key": "FSPIOP-Source",
-									"value": "{{payerfsp}}"
-								},
-								{
-									"key": "FSPIOP-Destination",
-									"value": "noresponsepayeefsp"
-								}
-							],
-							"body": {
-								"mode": "raw",
-								"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"99\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
-							},
-							"url": {
-								"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-								"host": [
-									"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-								],
-								"path": [
-									"transfers"
-								]
-							}
-						},
-						"response": []
-					},
-					{
-						"name": "Store Payerfsp position after Prepare",
-						"event": [{
-							"listen": "test",
-							"script": {
-								"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.environment.set(\"payerfspPositionAfterPrepare\", jsonData[0].value);",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "prerequest",
-								"script": {
-									"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
-									"exec": [
-										"setTimeout(function () {",
-										"  pm.sendRequest('www.google.com', function (err, response) {}",
-										"    );",
-										"}, 3000)"
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "GET",
-							"header": [{
-								"key": "FSPIOP-Source",
-								"type": "text",
-								"value": "{{payerfsp}}"
-							}],
-							"body": {
-								"mode": "raw",
-								"raw": ""
-							},
-							"url": {
-								"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
-								"host": [
-									"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-								],
-								"path": [
-									"participants",
-									"{{payerfsp}}",
-									"positions"
-								]
-							}
-						},
-						"response": []
-					},
-					{
-						"name": "Send Payee Abort",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
-								"exec": [
-									"pm.variables.set(\"completedTimestamp\",new Date().toISOString());"
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
-									"exec": [
-										"pm.test(\"Status code is 200\", function () {",
-										"    pm.response.to.have.status(200);",
-										"});",
-										"",
-										"setTimeout(function () {",
-										"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-										"          if(response.responseSize !== 0) {",
-										"              var jsonData = response.json();",
-										"              pm.test(\"Response code should be ABORTED\", function () {",
-										"                pm.expect(jsonData.transferState).to.eql('ABORTED');",
-										"              });",
-										"          } else {",
-										"              pm.test(\"Transfer FAILED\", function () {",
-										"                throw new Error('Did not receive response');",
-										"              });",
-										"              ",
-										"          }",
-										"   });",
-										"}, 5000)"
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{PAYEEFSP_BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "PUT",
-							"header": [{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
-								"value": "application/vnd.interoperability.transfers+json;version=1"
-							},
-								{
-									"key": "Date",
-									"type": "text",
-									"value": "{{dateHeader}}"
-								},
-								{
-									"key": "FSPIOP-Source",
-									"type": "text",
-									"value": "noresponsepayeefsp"
-								},
-								{
-									"key": "FSPIOP-Destination",
-									"type": "text",
-									"value": "{{payerfsp}}"
-								},
-								{
-									"key": "Accept",
-									"value": "application/vnd.interoperability.transfers+json;version=1",
-									"type": "text"
-								}
-							],
-							"body": {
-								"mode": "raw",
-								"raw": "{\n  \"fulfilment\": \"{{validFulfillment}}\",\n  \"completedTimestamp\": \"{{completedTimestamp}}\",\n  \"transferState\": \"ABORTED\"\n}"
-							},
-							"url": {
-								"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
-								"host": [
-									"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-								],
-								"path": [
-									"transfers",
-									"{{transfer_ID}}"
-								]
-							}
-						},
-						"response": []
-					},
-					{
-						"name": "Check Payerfsp Notification",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-								"exec": [
-									"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-									"   var uuid = require('uuid');",
-									"   var generatedUUID = uuid.v4();",
-									"   pm.variables.set('transferId', generatedUUID);",
-									"}",
-									"",
-									"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-									"   pm.variables.set('transferDate', (new Date()).toUTCString());",
-									"}"
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "6c54bbb2-0b33-4301-86ae-751142923a4c",
-									"exec": [
-										"pm.test(\"Status code is 202\", function () {",
-										"    pm.response.to.have.status(202);",
-										"});",
-										"",
-										"// pm.test(\"Check that Content-Type is present\", function () {",
-										"//     pm.response.to.have.header(\"Content-Type\");",
-										"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
-										"// });",
-										"",
-										"pm.test(\"Response status is ABORTED\", function () {",
-										"    pm.expect(pm.response.json().transferState).to.eql('ABORTED');",
-										"});",
-										"",
-										"",
-										""
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "GET",
-							"header": [{
-								"key": "Accept",
-								"value": "application/vnd.interoperability.transfers+json;version=1"
-							},
-								{
-									"key": "Content-Type",
-									"value": "application/vnd.interoperability.transfers+json;version=1.0"
-								},
-								{
-									"key": "Date",
-									"value": "{{transferDate}}"
-								},
-								{
-									"key": "FSPIOP-Source",
-									"value": "{{payerfsp}}"
-								},
-								{
-									"key": "FSPIOP-Destination",
-									"value": "{{payeefsp}}",
-									"disabled": true
-								}
-							],
-							"body": {
-								"mode": "raw",
-								"raw": ""
-							},
-							"url": {
-								"raw": "{{HOST_SIMULATOR}}/{{payerfsp}}/correlationid/{{transfer_ID}}",
-								"host": [
-									"{{HOST_SIMULATOR}}"
-								],
-								"path": [
-									"{{payerfsp}}",
-									"correlationid",
-									"{{transfer_ID}}"
-								]
-							}
-						},
-						"response": []
-					},
-					{
-						"name": "Check Headers",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-								"exec": [
-									"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-									"   var uuid = require('uuid');",
-									"   var generatedUUID = uuid.v4();",
-									"   pm.variables.set('transferId', generatedUUID);",
-									"}",
-									"",
-									"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-									"   pm.variables.set('transferDate', (new Date()).toUTCString());",
-									"}"
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "6c54bbb2-0b33-4301-86ae-751142923a4c",
-									"exec": [
-										"pm.test(\"Status code is 200\", function () {",
-										"    pm.response.to.have.status(200);",
-										"});",
-										"",
-										"// pm.test(\"Check that Content-Type is present\", function () {",
-										"//     pm.response.to.have.header(\"Content-Type\");",
-										"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
-										"// });",
-										"",
-										"pm.test(\"fspiop-source is switch\", function () {",
-										"    pm.expect(pm.response.json().headers['fspiop-source']).to.eql('noresponsepayeefsp');",
-										"});",
-										"",
-										"pm.test(\"fspiop-destination is payerfsp\", function () {",
-										"    pm.expect(pm.response.json().headers['fspiop-destination']).to.eql('payerfsp');",
-										"});",
-										"",
-										"pm.test(\"fspiop-signature is empty\", function () {",
-										"    pm.expect(pm.response.json().headers['fspiop-signature']).to.eql(undefined);",
-										"});",
-										"",
-										"pm.test(\"accept is empty\", function () {",
-										"    pm.expect(pm.response.json().headers['accept']).to.eql(undefined);",
-										"});",
-										"",
-										"pm.test(\"content-type should be application/vnd.interoperability.transfers+json;version=1\", function () {",
-										"    pm.expect(pm.response.json().headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1');",
-										"});",
-										"",
-										"pm.test(\"fspiop-uri is empty\", function () {",
-										"    pm.expect(pm.response.json().headers['fspiop-uri']).to.eql(undefined);",
-										"});",
-										"",
-										"pm.test(\"fspiop-http-method is empty\", function () {",
-										"    pm.expect(pm.response.json().headers['fspiop-http-method']).to.eql(undefined);",
-										"});"
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "GET",
-							"header": [{
-								"key": "Accept",
-								"value": "application/vnd.interoperability.transfers+json;version=1"
-							},
-								{
-									"key": "Content-Type",
-									"value": "application/vnd.interoperability.transfers+json;version=1.0"
-								},
-								{
-									"key": "Date",
-									"value": "{{transferDate}}"
-								},
-								{
-									"key": "FSPIOP-Source",
-									"value": "{{payerfsp}}"
-								},
-								{
-									"key": "FSPIOP-Destination",
-									"value": "{{payeefsp}}",
-									"disabled": true
-								}
-							],
-							"body": {
-								"mode": "raw",
-								"raw": ""
-							},
-							"url": {
-								"raw": "{{HOST_SIMULATOR}}/{{payerfsp}}/callbacks/{{transfer_ID}}",
-								"host": [
-									"{{HOST_SIMULATOR}}"
-								],
-								"path": [
-									"{{payerfsp}}",
-									"callbacks",
-									"{{transfer_ID}}"
-								]
-							}
-						},
-						"response": []
-					},
-					{
-						"name": "Check Transfer status - ABORTED",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-								"exec": [
-									"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-									"   var uuid = require('uuid');",
-									"   var generatedUUID = uuid.v4();",
-									"   pm.variables.set('transferId', generatedUUID);",
-									"}",
-									"",
-									"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-									"   pm.variables.set('transferDate', (new Date()).toUTCString());",
-									"}"
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "6c54bbb2-0b33-4301-86ae-751142923a4c",
-									"exec": [
-										"pm.test(\"Status code is 202\", function () {",
-										"    pm.response.to.have.status(202);",
-										"});",
-										"",
-										"// pm.test(\"Check that Content-Type is present\", function () {",
-										"//     pm.response.to.have.header(\"Content-Type\");",
-										"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
-										"// });",
-										"",
-										"setTimeout(function () {",
-										"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"transfer_ID\"), function (err, response) {",
-										"          if(response.responseSize !== 0) {",
-										"              var jsonData = response.json();",
-										"              ",
-										"              pm.test(\"Response status is ABORTED\", function () {",
-										"                pm.expect(jsonData.transferState).to.eql('ABORTED');",
-										"              });",
-										"          } else {",
-										"              pm.test(\"Transfer FAILED\", function () {",
-										"                throw new Error('Did not receive response');",
-										"              });",
-										"              ",
-										"          }",
-										"   });",
-										"}, 3000)",
-										"",
-										"",
-										""
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "GET",
-							"header": [{
-								"key": "Accept",
-								"value": "application/vnd.interoperability.transfers+json;version=1"
-							},
-								{
-									"key": "Content-Type",
-									"value": "application/vnd.interoperability.transfers+json;version=1.0"
-								},
-								{
-									"key": "Date",
-									"value": "{{transferDate}}"
-								},
-								{
-									"key": "FSPIOP-Source",
-									"value": "{{payerfsp}}"
-								},
-								{
-									"key": "FSPIOP-Destination",
-									"value": "{{payeefsp}}",
-									"disabled": true
-								}
-							],
-							"body": {
-								"mode": "raw",
-								"raw": ""
-							},
-							"url": {
-								"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
-								"host": [
-									"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-								],
-								"path": [
-									"transfers",
-									"{{transfer_ID}}"
-								]
-							}
-						},
-						"response": []
-					},
-					{
-						"name": "Check Payerfsp position after Abort",
-						"event": [{
-							"listen": "test",
-							"script": {
-								"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Payerfsp position after Payee ABORT should be same as position before prepare.\", function () {",
-									"    ",
-									"    pm.expect(jsonData[0].value).to.equal(Number(pm.environment.get('payerfspPositionBeforePrepare')));",
-									"});",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "prerequest",
-								"script": {
-									"id": "53c7e6de-d4c1-428e-a1c7-70fad0f3bed1",
-									"exec": [
-										"setTimeout(function () {",
-										"  pm.sendRequest('www.google.com', function (err, response) {}",
-										"    );",
-										"}, 10000)"
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "GET",
-							"header": [{
-								"key": "FSPIOP-Source",
-								"type": "text",
-								"value": "{{payerfsp}}"
-							}],
-							"body": {
-								"mode": "raw",
-								"raw": ""
-							},
-							"url": {
-								"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
-								"host": [
-									"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-								],
-								"path": [
-									"participants",
-									"{{payerfsp}}",
-									"positions"
-								]
-							}
-						},
-						"response": []
-					},
-					{
-						"name": "Check Payeefsp position after Abort",
-						"event": [{
-							"listen": "test",
-							"script": {
-								"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Payeefsp position after Payee ABORT should be same as position before prepare.\", function () {",
-									"    ",
-									"    pm.expect(jsonData[0].value).to.equal(Number(pm.environment.get('payeefspPositionBeforePrepare')));",
-									"});",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "prerequest",
-								"script": {
-									"id": "53c7e6de-d4c1-428e-a1c7-70fad0f3bed1",
-									"exec": [
-										"setTimeout(function () {",
-										"  pm.sendRequest('www.google.com', function (err, response) {}",
-										"    );",
-										"}, 10000)"
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "GET",
-							"header": [{
-								"key": "FSPIOP-Source",
-								"type": "text",
-								"value": "{{payerfsp}}"
-							}],
-							"body": {
-								"mode": "raw",
-								"raw": ""
-							},
-							"url": {
-								"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payeefsp}}/positions",
-								"host": [
-									"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-								],
-								"path": [
-									"participants",
-									"{{payeefsp}}",
-									"positions"
-								]
-							}
-						},
-						"response": []
-					}
-				],
-				"_postman_isSubFolder": true
-			},
+			"item": [
 				{
-					"name": "payee_invalid_fulfillment",
-					"item": [{
-						"name": "Send Quote",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-								"exec": [
-									"   var uuid = require('uuid');",
-									"   var generatedUUID = uuid.v4();",
-									"   pm.variables.set('quoteId', generatedUUID);",
-									"   generatedUUID = uuid.v4();",
-									"   pm.environment.set('transactionId', generatedUUID);",
-									"",
-									"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
-									"exec": [
-										"pm.test(\"Status code is 202\", function () {",
-										"    pm.response.to.have.status(202);",
-										"});",
-										"",
-										"pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
-										"",
-										"setTimeout(function () {",
-										"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-										"      if(response.responseSize !== 0) {",
-										"          console.log(response.json());",
-										"       pm.test(\"Response ilpPacket is not undefined\", function () {",
-										"           pm.expect(response.json().ilpPacket).not.equal(undefined);",
-										"           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
-										"       });",
-										"       ",
-										"       pm.test(\"Response condition is not undefined\", function () {",
-										"           pm.expect(response.json().condition).not.equal(undefined);",
-										"           pm.environment.set(\"condition\", response.json().condition);",
-										"       });",
-										"      } else {",
-										"          pm.test(\"Quote FAILED\", function () {",
-										"            throw new Error('Did not receive response');",
-										"           });",
-										"",
-										"      }",
-										"       ",
-										"   });",
-										"}, 1000)",
-										"",
-										"",
-										"",
-										""
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "POST",
-							"header": [{
-								"key": "Accept",
-								"value": "application/vnd.interoperability.quotes+json"
-							},
-								{
-									"key": "Content-Type",
-									"value": "application/vnd.interoperability.quotes+json;version=1.0"
-								},
-								{
-									"key": "Date",
-									"value": "{{dateHeader}}"
-								},
-								{
-									"key": "FSPIOP-Source",
-									"value": "{{payerfsp}}"
-								},
-								{
-									"key": "FSPIOP-Destination",
-									"value": "{{payeefsp}}"
-								}
-							],
-							"body": {
-								"mode": "raw",
-								"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"{{payeefsp}}\"\n    }\n  },\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"{{payerfsp}}\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"XOF\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
-							},
-							"url": {
-								"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
-								"host": [
-									"{{HOST_QUOTING_SERVICE}}"
-								],
-								"path": [
-									"quotes"
-								]
-							}
-						},
-						"response": []
-					},
+					"name": "payee_abort",
+					"item": [
 						{
-							"name": "Send Transfer Prepare",
-							"event": [{
-								"listen": "prerequest",
-								"script": {
-									"id": "373ce4bd-e96f-49df-a8e4-e2bd6e8490ab",
-									"exec": [
-										"var uuid = require('uuid');",
-										"var generatedUUID = uuid.v4();",
-										"pm.environment.set('transfer_ID', generatedUUID);",
-										"",
-										"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-										"   pm.variables.set('transferDate', (new Date()).toUTCString());",
-										"}",
-										"",
-										"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 1200000))",
-										""
-									],
-									"type": "text/javascript"
-								}
-							},
+							"name": "Store Payerfsp position before prepare",
+							"event": [
 								{
 									"listen": "test",
 									"script": {
-										"id": "ec961c23-5b9f-4509-9b30-4ea1de9a7b43",
+										"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
 										"exec": [
-											"pm.test(\"Status code is 202\", function () {",
-											"    pm.response.to.have.status(202);",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
 											"});",
 											"",
+											"var jsonData = pm.response.json();",
+											"",
+											"pm.environment.set(\"payerfspPositionBeforePrepare\", jsonData[0].value);",
 											"",
 											"",
-											"",
-											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
+										"exec": [
 											""
 										],
 										"type": "text/javascript"
@@ -7165,105 +6278,22 @@
 							"request": {
 								"auth": {
 									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
-								},
-								"method": "POST",
-								"header": [{
-									"key": "Accept",
-									"value": "application/vnd.interoperability.transfers+json;version=1"
-								},
-									{
-										"key": "Content-Type",
-										"value": "application/vnd.interoperability.transfers+json;version=1"
-									},
-									{
-										"key": "Date",
-										"value": "{{transferDate}}"
-									},
-									{
-										"key": "FSPIOP-Source",
-										"value": "{{payerfsp}}"
-									},
-									{
-										"key": "FSPIOP-Destination",
-										"value": "noresponsepayeefsp"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"10\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
-								},
-								"url": {
-									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-									"host": [
-										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-									],
-									"path": [
-										"transfers"
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
 									]
 								},
-								"description": "send a tranfer request with ilp packet and condition that are generated in quotes response along with expiry, fspiop source,fspiop destination, amount and currency."
-							},
-							"response": []
-						},
-						{
-							"name": "Store Payerfsp position",
-							"event": [{
-								"listen": "test",
-								"script": {
-									"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
-									"exec": [
-										"pm.test(\"Status code is 200\", function () {",
-										"    pm.response.to.have.status(200);",
-										"});",
-										"",
-										"var jsonData = pm.response.json();",
-										"",
-										"pm.environment.set(\"payerfspPositionBeforeTransfer\", jsonData[0].value);",
-										"",
-										"",
-										""
-									],
-									"type": "text/javascript"
-								}
-							},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
-										"exec": [
-											"setTimeout(function () {",
-											"  pm.sendRequest('www.google.com', function (err, response) {}",
-											"    );",
-											"}, 3000)"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
-								},
 								"method": "GET",
-								"header": [{
-									"key": "FSPIOP-Source",
-									"value": "{{payerfsp}}",
-									"type": "text"
-								}],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{payerfsp}}"
+									}
+								],
 								"url": {
 									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
 									"host": [
@@ -7279,35 +6309,33 @@
 							"response": []
 						},
 						{
-							"name": "Store Payeefsp position",
-							"event": [{
-								"listen": "test",
-								"script": {
-									"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
-									"exec": [
-										"pm.test(\"Status code is 200\", function () {",
-										"    pm.response.to.have.status(200);",
-										"});",
-										"",
-										"var jsonData = pm.response.json();",
-										"",
-										"pm.environment.set(\"payeefspPositionBeforeTransfer\", jsonData[0].value);",
-										"",
-										"",
-										""
-									],
-									"type": "text/javascript"
-								}
-							},
+							"name": "Store Payeefsp position before prepare",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"",
+											"pm.environment.set(\"payeefspPositionBeforePrepare\", jsonData[0].value);",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
 								{
 									"listen": "prerequest",
 									"script": {
 										"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
 										"exec": [
-											"setTimeout(function () {",
-											"  pm.sendRequest('www.google.com', function (err, response) {}",
-											"    );",
-											"}, 3000)"
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -7316,22 +6344,22 @@
 							"request": {
 								"auth": {
 									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
 								},
 								"method": "GET",
-								"header": [{
-									"key": "FSPIOP-Source",
-									"type": "text",
-									"value": "{{payerfsp}}"
-								}],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{payerfsp}}"
+									}
+								],
 								"url": {
 									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payeefsp}}/positions",
 									"host": [
@@ -7347,354 +6375,24 @@
 							"response": []
 						},
 						{
-							"name": "Send Payee Invalid Fulfillment",
-							"event": [{
-								"listen": "prerequest",
-								"script": {
-									"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
-									"exec": [
-										"pm.environment.set(\"completedTimestamp\",new Date().toISOString());",
-										""
-									],
-									"type": "text/javascript"
-								}
-							},
-								{
-									"listen": "test",
-									"script": {
-										"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
-										"exec": [
-											"pm.test(\"Status code is 400\", function () {",
-											"    pm.response.to.have.status(400);",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
-								},
-								"method": "PUT",
-								"header": [{
-									"key": "Content-Type",
-									"name": "Content-Type",
-									"type": "text",
-									"value": "application/vnd.interoperability.transfers+json;version=1"
-								},
-									{
-										"key": "Date",
-										"type": "text",
-										"value": "{{dateHeader}}"
-									},
-									{
-										"key": "FSPIOP-Source",
-										"type": "text",
-										"value": "noresponsepayeefsp"
-									},
-									{
-										"key": "FSPIOP-Destination",
-										"type": "text",
-										"value": "{{payeefsp}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"fulfilment\": \"{{invalidFulfillment}}\",\n  \"completedTimestamp\": \"{{completedTimestamp}}\",\n  \"transferState\": \"COMMITTED\"\n}"
-								},
-								"url": {
-									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
-									"host": [
-										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-									],
-									"path": [
-										"transfers",
-										"{{transfer_ID}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Check Transfer status - RESERVED",
-							"event": [{
-								"listen": "prerequest",
-								"script": {
-									"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-									"exec": [
-										"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-										"   var uuid = require('uuid');",
-										"   var generatedUUID = uuid.v4();",
-										"   pm.variables.set('transferId', generatedUUID);",
-										"}",
-										"",
-										"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-										"   pm.variables.set('transferDate', (new Date()).toUTCString());",
-										"}"
-									],
-									"type": "text/javascript"
-								}
-							},
-								{
-									"listen": "test",
-									"script": {
-										"id": "6c54bbb2-0b33-4301-86ae-751142923a4c",
-										"exec": [
-											"pm.test(\"Status code is 202\", function () {",
-											"    pm.response.to.have.status(202);",
-											"});",
-											"",
-											"// pm.test(\"Check that Content-Type is present\", function () {",
-											"//     pm.response.to.have.header(\"Content-Type\");",
-											"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
-											"// });",
-											"",
-											"setTimeout(function () {",
-											"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"transfer_ID\"), function (err, response) {",
-											"          if(response.responseSize !== 0) {",
-											"              var jsonData = response.json();",
-											"              ",
-											"              pm.test(\"Response status is RESERVED\", function () {",
-											"                pm.expect(jsonData.transferState).to.eql('RESERVED');",
-											"              });",
-											"          } else {",
-											"              pm.test(\"Transfer FAILED\", function () {",
-											"                throw new Error('Did not receive response');",
-											"              });",
-											"",
-											"          }",
-											"   });",
-											"}, 3000)",
-											"",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
-								},
-								"method": "GET",
-								"header": [{
-									"key": "Accept",
-									"value": "application/vnd.interoperability.transfers+json;version=1"
-								},
-									{
-										"key": "Content-Type",
-										"value": "application/vnd.interoperability.transfers+json;version=1.0"
-									},
-									{
-										"key": "Date",
-										"value": "{{transferDate}}"
-									},
-									{
-										"key": "FSPIOP-Source",
-										"value": "{{payerfsp}}"
-									},
-									{
-										"key": "FSPIOP-Destination",
-										"value": "{{payeefsp}}",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
-									"host": [
-										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-									],
-									"path": [
-										"transfers",
-										"{{transfer_ID}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Check Payerfsp&Payeefsp position",
-							"event": [{
-								"listen": "test",
-								"script": {
-									"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
-									"exec": [
-										"pm.test(\"Status code is 200\", function () {",
-										"    pm.response.to.have.status(200);",
-										"});",
-										"",
-										"var jsonData = pm.response.json();",
-										"",
-										"pm.test(\"Payerfsp position after transfer and after Payee ABORT should be same as position before transfer.\", function () {",
-										"    ",
-										"    pm.expect(jsonData[0].value).to.equal(Number(pm.environment.get('payerfspPositionBeforeTransfer')));",
-										"});",
-										"",
-										""
-									],
-									"type": "text/javascript"
-								}
-							},
+							"name": "Send Prepare",
+							"event": [
 								{
 									"listen": "prerequest",
 									"script": {
-										"id": "53c7e6de-d4c1-428e-a1c7-70fad0f3bed1",
+										"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
 										"exec": [
-											"setTimeout(function () {",
-											"  pm.sendRequest('www.google.com', function (err, response) {}",
-											"    );",
-											"}, 10000)"
+											"",
+											"var uuid = require('uuid');",
+											"var generatedUUID = uuid.v4();",
+											"pm.environment.set('transfer_ID', generatedUUID);",
+											"pm.environment.set('transferDate', (new Date()).toUTCString());",
+											"",
+											"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 600000))"
 										],
 										"type": "text/javascript"
 									}
-								}
-							],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
 								},
-								"method": "GET",
-								"header": [{
-									"key": "FSPIOP-Source",
-									"value": "{{payerfsp}}",
-									"type": "text"
-								}],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
-									"host": [
-										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-									],
-									"path": [
-										"participants",
-										"{{payerfsp}}",
-										"positions"
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "transfer_timeout",
-					"item": [{
-						"name": "Store Payerfsp position before prepare",
-						"event": [{
-							"listen": "test",
-							"script": {
-								"id": "2abb223b-656f-4eee-8b21-3ccb4ecbcba2",
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"var jsonData = pm.response.json();",
-									"",
-									"",
-									"",
-									"var result",
-									"jsonData.forEach( entry => {(entry.currency === pm.environment.get(\"currency\")) ? result = entry.value: result =",
-									" undefined})",
-									"pm.environment.set(\"payerfspPositionBeforePrepare\", result);",
-									"",
-									"",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "prerequest",
-								"script": {
-									"id": "b709f48d-c109-4f25-88cd-0fa237cfbd6e",
-									"exec": [
-										""
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"auth": {
-								"type": "bearer",
-								"bearer": [{
-									"key": "token",
-									"value": "{{BEARER_TOKEN}}",
-									"type": "string"
-								}]
-							},
-							"method": "GET",
-							"header": [{
-								"key": "FSPIOP-Source",
-								"type": "text",
-								"value": "{{payerfsp}}"
-							}],
-							"body": {
-								"mode": "raw",
-								"raw": ""
-							},
-							"url": {
-								"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
-								"host": [
-									"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-								],
-								"path": [
-									"participants",
-									"{{payerfsp}}",
-									"positions"
-								]
-							}
-						},
-						"response": []
-					},
-						{
-							"name": "Send Prepare",
-							"event": [{
-								"listen": "prerequest",
-								"script": {
-									"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-									"exec": [
-										"",
-										"var uuid = require('uuid');",
-										"var generatedUUID = uuid.v4();",
-										"pm.environment.set('transfer_ID', generatedUUID);",
-										"pm.environment.set('transferDate', (new Date()).toUTCString());",
-										"//pm.environment.set('transferAmount', 100);",
-										"",
-										"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 30000))"
-									],
-									"type": "text/javascript"
-								}
-							},
 								{
 									"listen": "test",
 									"script": {
@@ -7716,17 +6414,20 @@
 							"request": {
 								"auth": {
 									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
 								},
 								"method": "POST",
-								"header": [{
-									"key": "Accept",
-									"value": "application/vnd.interoperability.transfers+json;version=1"
-								},
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
 									{
 										"key": "Content-Type",
 										"value": "application/vnd.interoperability.transfers+json;version=1"
@@ -7746,7 +6447,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"10\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"nMel-FDPpp3T77jfC11fUXdcy935hy089AJ9v2OTXBI\"\n}"
+									"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"99\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
 								},
 								"url": {
 									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
@@ -7761,40 +6462,213 @@
 							"response": []
 						},
 						{
-							"name": "Check Payerfsp position before timeout",
-							"event": [{
-								"listen": "test",
-								"script": {
-									"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
-									"exec": [
-										"pm.test(\"Status code is 200\", function () {",
-										"    pm.response.to.have.status(200);",
-										"});",
-										"",
-										"var jsonData = pm.response.json();",
-										"var result;",
-										"",
-										"jsonData.forEach( entry => {(entry.currency === pm.environment.get(\"currency\")) ? result = entry.value: result =",
-										" undefined})",
-										"",
-										"pm.test(\"Payerfsp position after Prepare should be same as position before prepare+transfer amount\", function () {",
-										"    ",
-										"    var expectedValue = Number(pm.environment.get('payerfspPositionBeforePrepare'))+10",
-										"    ",
-										"    pm.expect(result).to.equal(expectedValue);",
-										"});",
-										"",
-										"",
-										""
-									],
-									"type": "text/javascript"
-								}
-							},
+							"name": "Store Payerfsp position after Prepare",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"",
+											"pm.environment.set(\"payerfspPositionAfterPrepare\", jsonData[0].value);",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
 								{
 									"listen": "prerequest",
 									"script": {
 										"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
 										"exec": [
+											"setTimeout(function () {",
+											"  pm.sendRequest('www.google.com', function (err, response) {}",
+											"    );",
+											"}, 3000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{payerfsp}}"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payerfsp}}",
+										"positions"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Send Payee Abort",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
+										"exec": [
+											"pm.variables.set(\"completedTimestamp\",new Date().toISOString());"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"setTimeout(function () {",
+											"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+											"          if(response.responseSize !== 0) {",
+											"              var jsonData = response.json();",
+											"              pm.test(\"Response code should be ABORTED\", function () {",
+											"                pm.expect(jsonData.transferState).to.eql('ABORTED');",
+											"              });",
+											"          } else {",
+											"              pm.test(\"Transfer FAILED\", function () {",
+											"                throw new Error('Did not receive response');",
+											"              });",
+											"              ",
+											"          }",
+											"   });",
+											"}, 5000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{PAYEEFSP_BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Date",
+										"type": "text",
+										"value": "{{dateHeader}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "noresponsepayeefsp"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"type": "text",
+										"value": "{{payerfsp}}"
+									},
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"fulfilment\": \"{{validFulfillment}}\",\n  \"completedTimestamp\": \"{{completedTimestamp}}\",\n  \"transferState\": \"ABORTED\"\n}"
+								},
+								"url": {
+									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
+									"host": [
+										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+									],
+									"path": [
+										"transfers",
+										"{{transfer_ID}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Check Payerfsp Notification",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+										"exec": [
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+											"   var uuid = require('uuid');",
+											"   var generatedUUID = uuid.v4();",
+											"   pm.variables.set('transferId', generatedUUID);",
+											"}",
+											"",
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+											"   pm.variables.set('transferDate', (new Date()).toUTCString());",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "6c54bbb2-0b33-4301-86ae-751142923a4c",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"// pm.test(\"Check that Content-Type is present\", function () {",
+											"//     pm.response.to.have.header(\"Content-Type\");",
+											"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
+											"// });",
+											"",
+											"pm.test(\"Response status is ABORTED\", function () {",
+											"    pm.expect(pm.response.json().transferState).to.eql('ABORTED');",
+											"});",
+											"",
+											"",
 											""
 										],
 										"type": "text/javascript"
@@ -7804,73 +6678,114 @@
 							"request": {
 								"auth": {
 									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
 								},
 								"method": "GET",
-								"header": [{
-									"key": "FSPIOP-Source",
-									"type": "text",
-									"value": "{{payerfsp}}"
-								}],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.transfers+json;version=1.0"
+									},
+									{
+										"key": "Date",
+										"value": "{{transferDate}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"value": "{{payeefsp}}",
+										"disabled": true
+									}
+								],
 								"url": {
-									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
+									"raw": "{{HOST_SIMULATOR}}/{{payerfsp}}/correlationid/{{transfer_ID}}",
 									"host": [
-										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+										"{{HOST_SIMULATOR}}"
 									],
 									"path": [
-										"participants",
 										"{{payerfsp}}",
-										"positions"
+										"correlationid",
+										"{{transfer_ID}}"
 									]
 								}
 							},
 							"response": []
 						},
 						{
-							"name": "Check Payerfsp position after timeout",
-							"event": [{
-								"listen": "test",
-								"script": {
-									"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
-									"exec": [
-										"pm.test(\"Status code is 200\", function () {",
-										"    pm.response.to.have.status(200);",
-										"});",
-										"",
-										"var jsonData = pm.response.json();",
-										"var result;",
-										"",
-										"jsonData.forEach( entry => {(entry.currency === pm.environment.get(\"currency\")) ? result = entry.value: result =",
-										" undefined})",
-										"",
-										"pm.test(\"Payerfsp position after timeout should be same as position before prepare.\", function () {",
-										"    ",
-										"    pm.expect(result).to.equal(Number(pm.environment.get('payerfspPositionBeforePrepare')));",
-										"});",
-										"",
-										"",
-										""
-									],
-									"type": "text/javascript"
-								}
-							},
+							"name": "Check Headers",
+							"event": [
 								{
 									"listen": "prerequest",
 									"script": {
-										"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
+										"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
 										"exec": [
-											"setTimeout(function () {",
-											"  pm.sendRequest('www.google.com', function (err, response) {}",
-											"    );",
-											"}, 40000)"
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+											"   var uuid = require('uuid');",
+											"   var generatedUUID = uuid.v4();",
+											"   pm.variables.set('transferId', generatedUUID);",
+											"}",
+											"",
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+											"   pm.variables.set('transferDate', (new Date()).toUTCString());",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "6c54bbb2-0b33-4301-86ae-751142923a4c",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"// pm.test(\"Check that Content-Type is present\", function () {",
+											"//     pm.response.to.have.header(\"Content-Type\");",
+											"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
+											"// });",
+											"",
+											"pm.test(\"fspiop-source is switch\", function () {",
+											"    pm.expect(pm.response.json().headers['fspiop-source']).to.eql('noresponsepayeefsp');",
+											"});",
+											"",
+											"pm.test(\"fspiop-destination is payerfsp\", function () {",
+											"    pm.expect(pm.response.json().headers['fspiop-destination']).to.eql('payerfsp');",
+											"});",
+											"",
+											"pm.test(\"fspiop-signature is empty\", function () {",
+											"    pm.expect(pm.response.json().headers['fspiop-signature']).to.eql(undefined);",
+											"});",
+											"",
+											"pm.test(\"accept is empty\", function () {",
+											"    pm.expect(pm.response.json().headers['accept']).to.eql(undefined);",
+											"});",
+											"",
+											"pm.test(\"content-type should be application/vnd.interoperability.transfers+json;version=1\", function () {",
+											"    pm.expect(pm.response.json().headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1');",
+											"});",
+											"",
+											"pm.test(\"fspiop-uri is empty\", function () {",
+											"    pm.expect(pm.response.json().headers['fspiop-uri']).to.eql(undefined);",
+											"});",
+											"",
+											"pm.test(\"fspiop-http-method is empty\", function () {",
+											"    pm.expect(pm.response.json().headers['fspiop-http-method']).to.eql(undefined);",
+											"});"
 										],
 										"type": "text/javascript"
 									}
@@ -7879,31 +6794,47 @@
 							"request": {
 								"auth": {
 									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
 								},
 								"method": "GET",
-								"header": [{
-									"key": "FSPIOP-Source",
-									"type": "text",
-									"value": "{{payerfsp}}"
-								}],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.transfers+json;version=1.0"
+									},
+									{
+										"key": "Date",
+										"value": "{{transferDate}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"value": "{{payeefsp}}",
+										"disabled": true
+									}
+								],
 								"url": {
-									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
+									"raw": "{{HOST_SIMULATOR}}/{{payerfsp}}/callbacks/{{transfer_ID}}",
 									"host": [
-										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+										"{{HOST_SIMULATOR}}"
 									],
 									"path": [
-										"participants",
 										"{{payerfsp}}",
-										"positions"
+										"callbacks",
+										"{{transfer_ID}}"
 									]
 								}
 							},
@@ -7911,24 +6842,25 @@
 						},
 						{
 							"name": "Check Transfer status - ABORTED",
-							"event": [{
-								"listen": "prerequest",
-								"script": {
-									"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-									"exec": [
-										"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-										"   var uuid = require('uuid');",
-										"   var generatedUUID = uuid.v4();",
-										"   pm.variables.set('transferId', generatedUUID);",
-										"}",
-										"",
-										"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-										"   pm.variables.set('transferDate', (new Date()).toUTCString());",
-										"}"
-									],
-									"type": "text/javascript"
-								}
-							},
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+										"exec": [
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+											"   var uuid = require('uuid');",
+											"   var generatedUUID = uuid.v4();",
+											"   pm.variables.set('transferId', generatedUUID);",
+											"}",
+											"",
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+											"   pm.variables.set('transferDate', (new Date()).toUTCString());",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
 								{
 									"listen": "test",
 									"script": {
@@ -7970,17 +6902,20 @@
 							"request": {
 								"auth": {
 									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
 								},
 								"method": "GET",
-								"header": [{
-									"key": "Accept",
-									"value": "application/vnd.interoperability.transfers+json;version=1"
-								},
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
 									{
 										"key": "Content-Type",
 										"value": "application/vnd.interoperability.transfers+json;version=1.0"
@@ -7999,9 +6934,575 @@
 										"disabled": true
 									}
 								],
+								"url": {
+									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
+									"host": [
+										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+									],
+									"path": [
+										"transfers",
+										"{{transfer_ID}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Check Payerfsp position after Abort",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"",
+											"pm.test(\"Payerfsp position after Payee ABORT should be same as position before prepare.\", function () {",
+											"    ",
+											"    pm.expect(jsonData[0].value).to.equal(Number(pm.environment.get('payerfspPositionBeforePrepare')));",
+											"});",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "53c7e6de-d4c1-428e-a1c7-70fad0f3bed1",
+										"exec": [
+											"setTimeout(function () {",
+											"  pm.sendRequest('www.google.com', function (err, response) {}",
+											"    );",
+											"}, 10000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{payerfsp}}"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payerfsp}}",
+										"positions"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Check Payeefsp position after Abort",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"",
+											"pm.test(\"Payeefsp position after Payee ABORT should be same as position before prepare.\", function () {",
+											"    ",
+											"    pm.expect(jsonData[0].value).to.equal(Number(pm.environment.get('payeefspPositionBeforePrepare')));",
+											"});",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "53c7e6de-d4c1-428e-a1c7-70fad0f3bed1",
+										"exec": [
+											"setTimeout(function () {",
+											"  pm.sendRequest('www.google.com', function (err, response) {}",
+											"    );",
+											"}, 10000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{payerfsp}}"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payeefsp}}/positions",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payeefsp}}",
+										"positions"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "payee_invalid_fulfillment",
+					"item": [
+						{
+							"name": "Send Quote",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+										"exec": [
+											"   var uuid = require('uuid');",
+											"   var generatedUUID = uuid.v4();",
+											"   pm.variables.set('quoteId', generatedUUID);",
+											"   generatedUUID = uuid.v4();",
+											"   pm.environment.set('transactionId', generatedUUID);",
+											"",
+											"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "029f9c14-13e7-4aac-ada8-572ccf2d502c",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"pm.environment.set('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE','false')",
+											"",
+											"setTimeout(function () {",
+											"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
+											"      if(response.responseSize !== 0) {",
+											"          console.log(response.json());",
+											"       pm.test(\"Response ilpPacket is not undefined\", function () {",
+											"           pm.expect(response.json().ilpPacket).not.equal(undefined);",
+											"           pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
+											"       });",
+											"       ",
+											"       pm.test(\"Response condition is not undefined\", function () {",
+											"           pm.expect(response.json().condition).not.equal(undefined);",
+											"           pm.environment.set(\"condition\", response.json().condition);",
+											"       });",
+											"      } else {",
+											"          pm.test(\"Quote FAILED\", function () {",
+											"            throw new Error('Did not receive response');",
+											"           });",
+											"",
+											"      }",
+											"       ",
+											"   });",
+											"}, 1000)",
+											"",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.quotes+json"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.quotes+json;version=1.0"
+									},
+									{
+										"key": "Date",
+										"value": "{{dateHeader}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"value": "{{payeefsp}}"
+									}
+								],
 								"body": {
 									"mode": "raw",
-									"raw": ""
+									"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{transactionId}}\",\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22556999125\",\n      \"fspId\": \"{{payeefsp}}\"\n    }\n  },\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"22507008181\",\n      \"fspId\": \"{{payerfsp}}\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"XOF\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+								},
+								"url": {
+									"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+									"host": [
+										"{{HOST_QUOTING_SERVICE}}"
+									],
+									"path": [
+										"quotes"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Send Transfer Prepare",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "373ce4bd-e96f-49df-a8e4-e2bd6e8490ab",
+										"exec": [
+											"var uuid = require('uuid');",
+											"var generatedUUID = uuid.v4();",
+											"pm.environment.set('transfer_ID', generatedUUID);",
+											"",
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+											"   pm.variables.set('transferDate', (new Date()).toUTCString());",
+											"}",
+											"",
+											"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 1200000))",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "ec961c23-5b9f-4509-9b30-4ea1de9a7b43",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"",
+											"",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Date",
+										"value": "{{transferDate}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"value": "noresponsepayeefsp"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"10\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
+								},
+								"url": {
+									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+									"host": [
+										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+									],
+									"path": [
+										"transfers"
+									]
+								},
+								"description": "send a tranfer request with ilp packet and condition that are generated in quotes response along with expiry, fspiop source,fspiop destination, amount and currency."
+							},
+							"response": []
+						},
+						{
+							"name": "Store Payerfsp position",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"",
+											"pm.environment.set(\"payerfspPositionBeforeTransfer\", jsonData[0].value);",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
+										"exec": [
+											"setTimeout(function () {",
+											"  pm.sendRequest('www.google.com', function (err, response) {}",
+											"    );",
+											"}, 3000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payerfsp}}",
+										"positions"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Store Payeefsp position",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"",
+											"pm.environment.set(\"payeefspPositionBeforeTransfer\", jsonData[0].value);",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
+										"exec": [
+											"setTimeout(function () {",
+											"  pm.sendRequest('www.google.com', function (err, response) {}",
+											"    );",
+											"}, 3000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{payerfsp}}"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payeefsp}}/positions",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payeefsp}}",
+										"positions"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Send Payee Invalid Fulfillment",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
+										"exec": [
+											"pm.environment.set(\"completedTimestamp\",new Date().toISOString());",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Date",
+										"type": "text",
+										"value": "{{dateHeader}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "noresponsepayeefsp"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"type": "text",
+										"value": "{{payeefsp}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"fulfilment\": \"{{invalidFulfillment}}\",\n  \"completedTimestamp\": \"{{completedTimestamp}}\",\n  \"transferState\": \"COMMITTED\"\n}"
 								},
 								"url": {
 									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
@@ -8017,25 +7518,629 @@
 							"response": []
 						},
 						{
-							"name": "Check Payerfsp Notification",
-							"event": [{
-								"listen": "prerequest",
-								"script": {
-									"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-									"exec": [
-										"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-										"   var uuid = require('uuid');",
-										"   var generatedUUID = uuid.v4();",
-										"   pm.variables.set('transferId', generatedUUID);",
-										"}",
-										"",
-										"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-										"   pm.variables.set('transferDate', (new Date()).toUTCString());",
-										"}"
+							"name": "Check Transfer status - RESERVED",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+										"exec": [
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+											"   var uuid = require('uuid');",
+											"   var generatedUUID = uuid.v4();",
+											"   pm.variables.set('transferId', generatedUUID);",
+											"}",
+											"",
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+											"   pm.variables.set('transferDate', (new Date()).toUTCString());",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "6c54bbb2-0b33-4301-86ae-751142923a4c",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"// pm.test(\"Check that Content-Type is present\", function () {",
+											"//     pm.response.to.have.header(\"Content-Type\");",
+											"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
+											"// });",
+											"",
+											"setTimeout(function () {",
+											"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"transfer_ID\"), function (err, response) {",
+											"          if(response.responseSize !== 0) {",
+											"              var jsonData = response.json();",
+											"              ",
+											"              pm.test(\"Response status is RESERVED\", function () {",
+											"                pm.expect(jsonData.transferState).to.eql('RESERVED');",
+											"              });",
+											"          } else {",
+											"              pm.test(\"Transfer FAILED\", function () {",
+											"                throw new Error('Did not receive response');",
+											"              });",
+											"",
+											"          }",
+											"   });",
+											"}, 3000)",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.transfers+json;version=1.0"
+									},
+									{
+										"key": "Date",
+										"value": "{{transferDate}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"value": "{{payeefsp}}",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
+									"host": [
+										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
 									],
-									"type": "text/javascript"
+									"path": [
+										"transfers",
+										"{{transfer_ID}}"
+									]
 								}
 							},
+							"response": []
+						},
+						{
+							"name": "Check Payerfsp&Payeefsp position",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"",
+											"pm.test(\"Payerfsp position after transfer and after Payee ABORT should be same as position before transfer.\", function () {",
+											"    ",
+											"    pm.expect(jsonData[0].value).to.equal(Number(pm.environment.get('payerfspPositionBeforeTransfer')));",
+											"});",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "53c7e6de-d4c1-428e-a1c7-70fad0f3bed1",
+										"exec": [
+											"setTimeout(function () {",
+											"  pm.sendRequest('www.google.com', function (err, response) {}",
+											"    );",
+											"}, 10000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payerfsp}}",
+										"positions"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "transfer_timeout",
+					"item": [
+						{
+							"name": "Store Payerfsp position before prepare",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "2abb223b-656f-4eee-8b21-3ccb4ecbcba2",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"",
+											"",
+											"",
+											"var result",
+											"jsonData.forEach( entry => {(entry.currency === pm.environment.get(\"currency\")) ? result = entry.value: result =",
+											" undefined})",
+											"pm.environment.set(\"payerfspPositionBeforePrepare\", result);",
+											"",
+											"",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "b709f48d-c109-4f25-88cd-0fa237cfbd6e",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{payerfsp}}"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payerfsp}}",
+										"positions"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Send Prepare",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+										"exec": [
+											"",
+											"var uuid = require('uuid');",
+											"var generatedUUID = uuid.v4();",
+											"pm.environment.set('transfer_ID', generatedUUID);",
+											"pm.environment.set('transferDate', (new Date()).toUTCString());",
+											"//pm.environment.set('transferAmount', 100);",
+											"",
+											"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 30000))"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Date",
+										"value": "{{dateHeader}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"value": "noresponsepayeefsp"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"10\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"nMel-FDPpp3T77jfC11fUXdcy935hy089AJ9v2OTXBI\"\n}"
+								},
+								"url": {
+									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+									"host": [
+										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+									],
+									"path": [
+										"transfers"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Check Payerfsp position before timeout",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"var result;",
+											"",
+											"jsonData.forEach( entry => {(entry.currency === pm.environment.get(\"currency\")) ? result = entry.value: result =",
+											" undefined})",
+											"",
+											"pm.test(\"Payerfsp position after Prepare should be same as position before prepare+transfer amount\", function () {",
+											"    ",
+											"    var expectedValue = Number(pm.environment.get('payerfspPositionBeforePrepare'))+10",
+											"    ",
+											"    pm.expect(result).to.equal(expectedValue);",
+											"});",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{payerfsp}}"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payerfsp}}",
+										"positions"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Check Payerfsp position after timeout",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "974f5e96-3667-491c-a5f7-940bf92bc755",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"var result;",
+											"",
+											"jsonData.forEach( entry => {(entry.currency === pm.environment.get(\"currency\")) ? result = entry.value: result =",
+											" undefined})",
+											"",
+											"pm.test(\"Payerfsp position after timeout should be same as position before prepare.\", function () {",
+											"    ",
+											"    pm.expect(result).to.equal(Number(pm.environment.get('payerfspPositionBeforePrepare')));",
+											"});",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "52a7b3f2-656d-45a5-b1f9-69414966f11b",
+										"exec": [
+											"setTimeout(function () {",
+											"  pm.sendRequest('www.google.com', function (err, response) {}",
+											"    );",
+											"}, 40000)"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "FSPIOP-Source",
+										"type": "text",
+										"value": "{{payerfsp}}"
+									}
+								],
+								"url": {
+									"raw": "{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{payerfsp}}/positions",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{payerfsp}}",
+										"positions"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Check Transfer status - ABORTED",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+										"exec": [
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+											"   var uuid = require('uuid');",
+											"   var generatedUUID = uuid.v4();",
+											"   pm.variables.set('transferId', generatedUUID);",
+											"}",
+											"",
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+											"   pm.variables.set('transferDate', (new Date()).toUTCString());",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "6c54bbb2-0b33-4301-86ae-751142923a4c",
+										"exec": [
+											"pm.test(\"Status code is 202\", function () {",
+											"    pm.response.to.have.status(202);",
+											"});",
+											"",
+											"// pm.test(\"Check that Content-Type is present\", function () {",
+											"//     pm.response.to.have.header(\"Content-Type\");",
+											"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
+											"// });",
+											"",
+											"setTimeout(function () {",
+											"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"transfer_ID\"), function (err, response) {",
+											"          if(response.responseSize !== 0) {",
+											"              var jsonData = response.json();",
+											"              ",
+											"              pm.test(\"Response status is ABORTED\", function () {",
+											"                pm.expect(jsonData.transferState).to.eql('ABORTED');",
+											"              });",
+											"          } else {",
+											"              pm.test(\"Transfer FAILED\", function () {",
+											"                throw new Error('Did not receive response');",
+											"              });",
+											"              ",
+											"          }",
+											"   });",
+											"}, 3000)",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.interoperability.transfers+json;version=1.0"
+									},
+									{
+										"key": "Date",
+										"value": "{{transferDate}}"
+									},
+									{
+										"key": "FSPIOP-Source",
+										"value": "{{payerfsp}}"
+									},
+									{
+										"key": "FSPIOP-Destination",
+										"value": "{{payeefsp}}",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
+									"host": [
+										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+									],
+									"path": [
+										"transfers",
+										"{{transfer_ID}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Check Payerfsp Notification",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+										"exec": [
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+											"   var uuid = require('uuid');",
+											"   var generatedUUID = uuid.v4();",
+											"   pm.variables.set('transferId', generatedUUID);",
+											"}",
+											"",
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+											"   pm.variables.set('transferDate', (new Date()).toUTCString());",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
 								{
 									"listen": "test",
 									"script": {
@@ -8061,17 +8166,20 @@
 							"request": {
 								"auth": {
 									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
 								},
 								"method": "GET",
-								"header": [{
-									"key": "Accept",
-									"value": "application/vnd.interoperability.transfers+json;version=1"
-								},
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
 									{
 										"key": "Content-Type",
 										"value": "application/vnd.interoperability.transfers+json;version=1.0"
@@ -8090,10 +8198,6 @@
 										"disabled": true
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{HOST_SIMULATOR}}/{{payerfsp}}/correlationid/{{transfer_ID}}",
 									"host": [
@@ -8110,24 +8214,25 @@
 						},
 						{
 							"name": "Check Headers",
-							"event": [{
-								"listen": "prerequest",
-								"script": {
-									"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-									"exec": [
-										"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-										"   var uuid = require('uuid');",
-										"   var generatedUUID = uuid.v4();",
-										"   pm.variables.set('transferId', generatedUUID);",
-										"}",
-										"",
-										"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-										"   pm.variables.set('transferDate', (new Date()).toUTCString());",
-										"}"
-									],
-									"type": "text/javascript"
-								}
-							},
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+										"exec": [
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+											"   var uuid = require('uuid');",
+											"   var generatedUUID = uuid.v4();",
+											"   pm.variables.set('transferId', generatedUUID);",
+											"}",
+											"",
+											"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+											"   pm.variables.set('transferDate', (new Date()).toUTCString());",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
 								{
 									"listen": "test",
 									"script": {
@@ -8177,17 +8282,20 @@
 							"request": {
 								"auth": {
 									"type": "bearer",
-									"bearer": [{
-										"key": "token",
-										"value": "{{BEARER_TOKEN}}",
-										"type": "string"
-									}]
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{BEARER_TOKEN}}",
+											"type": "string"
+										}
+									]
 								},
 								"method": "GET",
-								"header": [{
-									"key": "Accept",
-									"value": "application/vnd.interoperability.transfers+json;version=1"
-								},
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.interoperability.transfers+json;version=1"
+									},
 									{
 										"key": "Content-Type",
 										"value": "application/vnd.interoperability.transfers+json;version=1.0"
@@ -8206,10 +8314,6 @@
 										"disabled": true
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{HOST_SIMULATOR}}/{{payerfsp}}/callbacks/{{transfer_ID}}",
 									"host": [
@@ -8226,16 +8330,17 @@
 						}
 					],
 					"description": "Response body:\n: Received error in Transfers: {\"errorInformation\":{\"errorCode\":3100,\"errorDescription\":\"Generic validation error: Expiration date 2018-10-01T20:31:00.534Z is already in the past\"}}\n",
-					"event": [{
-						"listen": "prerequest",
-						"script": {
-							"id": "b3fe964b-e855-4f23-a870-b7d5bc0b8adf",
-							"type": "text/javascript",
-							"exec": [
-								""
-							]
-						}
-					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b3fe964b-e855-4f23-a870-b7d5bc0b8adf",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
 						{
 							"listen": "test",
 							"script": {
@@ -8251,16 +8356,17 @@
 				}
 			],
 			"description": "Author: Sridevi Miriyala",
-			"event": [{
-				"listen": "prerequest",
-				"script": {
-					"id": "cf834ce7-c6bf-476a-a78b-1955d247aac8",
-					"type": "text/javascript",
-					"exec": [
-						""
-					]
-				}
-			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "cf834ce7-c6bf-476a-a78b-1955d247aac8",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
 				{
 					"listen": "test",
 					"script": {
@@ -8275,686 +8381,20 @@
 		},
 		{
 			"name": "duplicate_handling",
-			"item": [{
-				"name": "transfers",
-				"item": [{
-					"name": "original_transfer_at_committed",
-					"item": [{
-						"name": "Send Transfer",
-						"event": [{
-							"listen": "test",
-							"script": {
-								"id": "900142b0-e4d7-43a4-a751-38202b600661",
-								"exec": [
-									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
-									"});",
-									"",
-									"// pm.test(\"Check that Content-Type is present\", function () {",
-									"//     pm.response.to.have.header(\"Content-Type\");",
-									"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
-									"// });",
-									"",
-									"setTimeout(function () {",
-									"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"transfer_ID\"), function (err, response) {",
-									"          if(response.responseSize !== 0) {",
-									"              var jsonData = response.json();",
-									"              pm.test(\"Response data does not have transferId\", function () {",
-									"               pm.expect(jsonData.transferId).to.eql(undefined);",
-									"             });",
-									"              pm.test(\"Response status is COMMITTED\", function () {",
-									"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-									"              });",
-									"          } else {",
-									"              pm.test(\"Transfer FAILED\", function () {",
-									"                throw new Error('Did not receive response');",
-									"              });",
-									"              ",
-									"          }",
-									"   });",
-									"}, 2000)",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-							{
-								"listen": "prerequest",
-								"script": {
-									"id": "20820c95-0a24-4906-a6ba-708d6ecf4a61",
-									"exec": [
-										"var uuid = require('uuid');",
-										"var generatedUUID = uuid.v4();",
-										"pm.environment.set('transfer_ID', generatedUUID);",
-										"",
-										"pm.variables.set('transferDate', (new Date()).toUTCString());",
-										"",
-										"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 60000))"
-									],
-									"type": "text/javascript"
-								}
-							}
-						],
-						"request": {
-							"method": "POST",
-							"header": [{
-								"key": "Accept",
-								"value": "application/vnd.interoperability.transfers+json;version=1"
-							},
-								{
-									"key": "Content-Type",
-									"value": "application/vnd.interoperability.transfers+json;version=1.0"
-								},
-								{
-									"key": "Date",
-									"value": "{{transferDate}}"
-								},
-								{
-									"key": "FSPIOP-Source",
-									"value": "{{payerfsp}}"
-								},
-								{
-									"key": "FSPIOP-Destination",
-									"value": "{{payeefsp}}"
-								}
-							],
-							"body": {
-								"mode": "raw",
-								"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"{{payeefsp}}\",\n  \"amount\": {\n    \"amount\": \"1\",\n    \"currency\": \"USD\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
-							},
-							"url": {
-								"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-								"host": [
-									"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-								],
-								"path": [
-									"transfers"
-								]
-							}
-						},
-						"response": []
-					},
+			"item": [
+				{
+					"name": "transfers",
+					"item": [
 						{
-							"name": "Duplicate Transfer",
-							"event": [{
-								"listen": "test",
-								"script": {
-									"id": "900142b0-e4d7-43a4-a751-38202b600661",
-									"exec": [
-										"pm.test(\"Status code is 202\", function () {",
-										"    pm.response.to.have.status(202);",
-										"});",
-										"",
-										"// pm.test(\"Check that Content-Type is present\", function () {",
-										"//     pm.response.to.have.header(\"Content-Type\");",
-										"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
-										"// });",
-										"",
-										"setTimeout(function () {",
-										"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.variables.get(\"transfer_ID\"), function (err, response) {",
-										"          if(response.responseSize !== 0) {",
-										"              var jsonData = response.json().data;",
-										"              var headers = response.json().headers",
-										"              pm.test(\"Response data does not have transferId\", function () {",
-										"               pm.expect(jsonData.transferId).to.eql(undefined);",
-										"             });",
-										"              pm.test(\"Response status is COMMITTED\", function () {",
-										"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-										"              });",
-										"              pm.test(\"fspiop-source is switch\", function () {",
-										"                pm.expect(headers['fspiop-source']).to.eql('switch');",
-										"              });",
-										"              pm.test(\"fspiop-destination is payerfsp\", function () {",
-										"                pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
-										"              });",
-										"          } else {",
-										"              pm.test(\"Transfer FAILED\", function () {",
-										"                throw new Error('Did not receive response');",
-										"              });",
-										"              ",
-										"          }",
-										"   });",
-										"}, 2000)",
-										"",
-										"",
-										""
-									],
-									"type": "text/javascript"
-								}
-							},
+							"name": "original_transfer_at_committed",
+							"item": [
 								{
-									"listen": "prerequest",
-									"script": {
-										"id": "20820c95-0a24-4906-a6ba-708d6ecf4a61",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [{
-									"key": "Accept",
-									"value": "application/vnd.interoperability.transfers+json;version=1"
-								},
-									{
-										"key": "Content-Type",
-										"value": "application/vnd.interoperability.transfers+json;version=1.0"
-									},
-									{
-										"key": "Date",
-										"value": "{{transferDate}}"
-									},
-									{
-										"key": "FSPIOP-Source",
-										"value": "{{payerfsp}}"
-									},
-									{
-										"key": "FSPIOP-Destination",
-										"value": "{{payeefsp}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"{{payeefsp}}\",\n  \"amount\": {\n    \"amount\": \"1\",\n    \"currency\": \"USD\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
-								},
-								"url": {
-									"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-									"host": [
-										"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-									],
-									"path": [
-										"transfers"
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-					{
-						"name": "fulfill_commit",
-						"item": [{
-							"name": "positive",
-							"item": [{
-								"name": "Send Quote",
-								"event": [{
-									"listen": "prerequest",
-									"script": {
-										"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-										"exec": [
-											"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-											"   var uuid = require('uuid');",
-											"   var generatedUUID = uuid.v4();",
-											"   pm.variables.set('quoteId', generatedUUID);",
-											"}",
-											"",
-											"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-											"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								},
-									{
-										"listen": "test",
-										"script": {
-											"id": "b7ca6bc0-b58a-46d8-8881-2db1aa0703ef",
-											"exec": [
-												"pm.test(\"Status code is 202\", function () {",
-												"    pm.response.to.have.status(202);",
-												"});",
-												"",
-												"// pm.test(\"Check that Content-Type is present\", function () {",
-												"//     pm.response.to.have.header(\"Content-Type\");",
-												"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.quotes+json;version=1.0\");",
-												"// });",
-												"",
-												"",
-												"setTimeout(function () {",
-												"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-												"      if(response.responseSize !== 0) {",
-												"          console.log('response: ',response.json());",
-												"       pm.test(\"Response ilpPacket is not undefined\", function () {",
-												"           console.log('ilpPacket: ',response.json().ilpPacket)",
-												"           pm.expect(response.json().ilpPacket).not.eql(undefined);",
-												"          pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
-												"           ",
-												"       });",
-												"       ",
-												"       pm.test(\"Response condition is not undefined\", function () {",
-												"           pm.expect(response.json().condition).not.eql(undefined);",
-												"           pm.environment.set(\"condition\", response.json().condition);",
-												"       });",
-												"      } else {",
-												"          pm.test(\"Quote FAILED\", function () {",
-												"            throw new Error('Did not receive response');",
-												"           });",
-												"",
-												"      }",
-												"       ",
-												"   });",
-												"}, 1000)",
-												"",
-												"",
-												""
-											],
-											"type": "text/javascript"
-										}
-									}
-								],
-								"request": {
-									"method": "POST",
-									"header": [{
-										"key": "Accept",
-										"value": "application/vnd.interoperability.quotes+json;version=1"
-									},
-										{
-											"key": "Content-Type",
-											"value": "application/vnd.interoperability.quotes+json;version=1.0"
-										},
-										{
-											"key": "Date",
-											"value": "{{quoteDate}}"
-										},
-										{
-											"key": "FSPIOP-SOurce",
-											"value": "{{payerfsp}}"
-										},
-										{
-											"key": "FSPIOP-Destination",
-											"value": "{{payeefsp}}"
-										}
-									],
-									"body": {
-										"mode": "raw",
-										"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{quoteId}}\",\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"{{receiverMSISDN}}\",\n      \"fspId\": \"{{payeefsp}}\"\n    }\n  },\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"27713803905\",\n      \"fspId\": \"{{payerfsp}}\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
-									},
-									"url": {
-										"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
-										"host": [
-											"{{HOST_QUOTING_SERVICE}}"
-										],
-										"path": [
-											"quotes"
-										]
-									}
-								},
-								"response": []
-							},
-								{
-									"name": "Send Transfer-Prepare",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-											"exec": [
-												"",
-												"var uuid = require('uuid');",
-												"var generatedUUID = uuid.v4();",
-												"pm.environment.set('transfer_ID', generatedUUID);",
-												"pm.environment.set('transferDate', (new Date()).toUTCString());",
-												"pm.environment.set('transferAmount', 100);",
-												"",
-												"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 60000))"
-											],
-											"type": "text/javascript"
-										}
-									},
+									"name": "Send Transfer",
+									"event": [
 										{
 											"listen": "test",
 											"script": {
-												"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"",
-													"",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.transfers+json;version=1"
-										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.transfers+json;version=1"
-											},
-											{
-												"key": "Date",
-												"value": "{{dateHeader}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"value": "{{payerfsp}}"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "noresponsepayeefsp"
-											},
-											{
-												"key": "FSPIOP-Signature",
-												"value": "{{fspiop-signature}}",
-												"type": "text"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-											"host": [
-												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-											],
-											"path": [
-												"transfers"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Fulfill",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
-											"exec": [
-												"pm.environment.set(\"completedTimestamp\",new Date().toISOString());"
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
-												"exec": [
-													"pm.test(\"Status code is 200\", function () {",
-													"    pm.response.to.have.status(200);",
-													"});",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-													"          if(response.responseSize !== 0) {",
-													"              //Check headers",
-													"              var headers = response.json().headers;",
-													"              ",
-													"                pm.test(\"fspiop-source is noresponsepayeefsp\", function () {",
-													"                    pm.expect(headers['fspiop-source']).to.eql('noresponsepayeefsp');",
-													"                });",
-													"                ",
-													"                pm.test(\"fspiop-destination is payerfsp\", function () {",
-													"                    pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
-													"                });",
-													"                ",
-													"                //Uncomment after JWS is implemented",
-													"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
-													"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
-													"                // });",
-													"                ",
-													"                ",
-													"                pm.test(\"payeefsp content-type is same as sent in the request\", function () {",
-													"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-													"                });",
-													"                ",
-													"                pm.test(\"date header should not be empty\", function () {",
-													"                    pm.expect(headers['date']).to.be.not.empty;",
-													"                });",
-													"                ",
-													"                pm.test(\"accept header should not be sent in the response\", function () {",
-													"                    pm.expect(headers['accept']).to.eql(undefined);",
-													"                });",
-													"                ",
-													"              //Check data",
-													"              var jsonData = response.json().data;",
-													"              pm.test(\"Response transferState should be COMMITTED\", function () {",
-													"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-													"              });",
-													"              ",
-													"              pm.test(\"Response fulfilment should be same as in request\", function () {",
-													"                pm.expect(jsonData.fulfilment).to.eql(pm.environment.get(\"validFulfillment\"));",
-													"              });",
-													"              ",
-													"          } else {",
-													"              pm.test(\"Transfer FAILED\", function () {",
-													"                throw new Error('Did not receive response');",
-													"              });",
-													"",
-													"          }",
-													"   });",
-													"}, 5000)"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{PAYEEFSP_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "PUT",
-										"header": [{
-											"key": "Content-Type",
-											"name": "Content-Type",
-											"type": "text",
-											"value": "application/vnd.interoperability.transfers+json;version=1.0"
-										},
-											{
-												"key": "Date",
-												"type": "text",
-												"value": "{{dateHeader}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"type": "text",
-												"value": "noresponsepayeefsp"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"type": "text",
-												"value": "{{payerfsp}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"fulfilment\": \"{{validFulfillment}}\",\n  \"completedTimestamp\": \"{{completedTimestamp}}\",\n  \"transferState\": \"COMMITTED\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
-											"host": [
-												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-											],
-											"path": [
-												"transfers",
-												"{{transfer_ID}}"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Duplicate Fulfill",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
-											"exec": [
-												""
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
-												"exec": [
-													"pm.test(\"Status code is 200\", function () {",
-													"    pm.response.to.have.status(200);",
-													"});",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/noresponsepayeefsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-													"          if(response.responseSize !== 0) {",
-													"              ",
-													"              //Check headers",
-													"              var headers = response.json().headers;",
-													"              ",
-													"                pm.test(\"fspiop-source is switch\", function () {",
-													"                    pm.expect(headers['fspiop-source']).to.eql('switch');",
-													"                });",
-													"                ",
-													"                pm.test(\"fspiop-destination is noresponsepayeefsp\", function () {",
-													"                    pm.expect(headers['fspiop-destination']).to.eql('noresponsepayeefsp');",
-													"                });",
-													"                ",
-													"                //Uncomment after JWS is implemented",
-													"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
-													"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
-													"                // });",
-													"                ",
-													"                ",
-													"                pm.test(\" content-type is same as sent in the request\", function () {",
-													"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-													"                });",
-													"                ",
-													"                pm.test(\"date header should not be empty\", function () {",
-													"                    pm.expect(headers['date']).to.be.not.empty;",
-													"                });",
-													"                ",
-													"                pm.test(\"accept header should not be sent in the response\", function () {",
-													"                    pm.expect(headers['accept']).to.eql(undefined);",
-													"                });",
-													"                ",
-													"             //Check data    ",
-													"              var jsonData = response.json().data;",
-													"              pm.test(\"Response transferState should be COMMITTED\", function () {",
-													"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-													"              });",
-													"              ",
-													"              pm.test(\"Response fulfilment should be same as in request\", function () {",
-													"                pm.expect(jsonData.fulfilment).to.eql(pm.environment.get(\"validFulfillment\"));",
-													"              });",
-													"          } else {",
-													"              pm.test(\"Transfer FAILED\", function () {",
-													"                throw new Error('Did not receive response');",
-													"              });",
-													"              ",
-													"          }",
-													"   });",
-													"}, 5000)"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{PAYEEFSP_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "PUT",
-										"header": [{
-											"key": "Content-Type",
-											"name": "Content-Type",
-											"type": "text",
-											"value": "application/vnd.interoperability.transfers+json;version=1.0"
-										},
-											{
-												"key": "Date",
-												"type": "text",
-												"value": "{{dateHeader}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"type": "text",
-												"value": "noresponsepayeefsp"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"type": "text",
-												"value": "{{payerfsp}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"fulfilment\": \"{{validFulfillment}}\",\n  \"completedTimestamp\": \"{{completedTimestamp}}\",\n  \"transferState\": \"COMMITTED\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
-											"host": [
-												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-											],
-											"path": [
-												"transfers",
-												"{{transfer_ID}}"
-											]
-										}
-									},
-									"response": []
-								}
-							],
-							"_postman_isSubFolder": true
-						},
-							{
-								"name": "negative",
-								"item": [{
-									"name": "Send Quote",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-											"exec": [
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.variables.set('quoteId', generatedUUID);",
-												"}",
-												"",
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-												"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-												"}"
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "b7ca6bc0-b58a-46d8-8881-2db1aa0703ef",
+												"id": "900142b0-e4d7-43a4-a751-38202b600661",
 												"exec": [
 													"pm.test(\"Status code is 202\", function () {",
 													"    pm.response.to.have.status(202);",
@@ -8962,615 +8402,65 @@
 													"",
 													"// pm.test(\"Check that Content-Type is present\", function () {",
 													"//     pm.response.to.have.header(\"Content-Type\");",
-													"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.quotes+json;version=1.0\");",
+													"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
 													"// });",
 													"",
-													"",
 													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-													"      if(response.responseSize !== 0) {",
-													"          console.log('response: ',response.json());",
-													"       pm.test(\"Response ilpPacket is not undefined\", function () {",
-													"           console.log('ilpPacket: ',response.json().ilpPacket)",
-													"           pm.expect(response.json().ilpPacket).not.eql(undefined);",
-													"          pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
-													"           ",
-													"       });",
-													"       ",
-													"       pm.test(\"Response condition is not undefined\", function () {",
-													"           pm.expect(response.json().condition).not.eql(undefined);",
-													"           pm.environment.set(\"condition\", response.json().condition);",
-													"       });",
-													"      } else {",
-													"          pm.test(\"Quote FAILED\", function () {",
-													"            throw new Error('Did not receive response');",
-													"           });",
-													"",
-													"      }",
-													"       ",
+													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"transfer_ID\"), function (err, response) {",
+													"          if(response.responseSize !== 0) {",
+													"              var jsonData = response.json();",
+													"              pm.test(\"Response data does not have transferId\", function () {",
+													"               pm.expect(jsonData.transferId).to.eql(undefined);",
+													"             });",
+													"              pm.test(\"Response status is COMMITTED\", function () {",
+													"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+													"              });",
+													"          } else {",
+													"              pm.test(\"Transfer FAILED\", function () {",
+													"                throw new Error('Did not receive response');",
+													"              });",
+													"              ",
+													"          }",
 													"   });",
-													"}, 1000)",
+													"}, 2000)",
 													"",
 													"",
 													""
 												],
 												"type": "text/javascript"
 											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.quotes+json;version=1"
 										},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.interoperability.quotes+json;version=1.0"
-											},
-											{
-												"key": "Date",
-												"value": "{{quoteDate}}"
-											},
-											{
-												"key": "FSPIOP-SOurce",
-												"value": "{{payerfsp}}"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"value": "{{payeefsp}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{quoteId}}\",\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"{{receiverMSISDN}}\",\n      \"fspId\": \"{{payeefsp}}\"\n    }\n  },\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"27713803905\",\n      \"fspId\": \"{{payerfsp}}\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
-										},
-										"url": {
-											"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
-											"host": [
-												"{{HOST_QUOTING_SERVICE}}"
-											],
-											"path": [
-												"quotes"
-											]
-										}
-									},
-									"response": []
-								},
-									{
-										"name": "Send Transfer-Prepare",
-										"event": [{
+										{
 											"listen": "prerequest",
 											"script": {
-												"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+												"id": "20820c95-0a24-4906-a6ba-708d6ecf4a61",
 												"exec": [
-													"",
 													"var uuid = require('uuid');",
 													"var generatedUUID = uuid.v4();",
 													"pm.environment.set('transfer_ID', generatedUUID);",
-													"pm.environment.set('transferDate', (new Date()).toUTCString());",
-													"pm.environment.set('transferAmount', 100);",
+													"",
+													"pm.variables.set('transferDate', (new Date()).toUTCString());",
 													"",
 													"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 60000))"
 												],
 												"type": "text/javascript"
 											}
-										},
-											{
-												"listen": "test",
-												"script": {
-													"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
-													"exec": [
-														"pm.test(\"Status code is 202\", function () {",
-														"    pm.response.to.have.status(202);",
-														"});",
-														"",
-														"",
-														"",
-														"",
-														""
-													],
-													"type": "text/javascript"
-												}
-											}
-										],
-										"request": {
-											"auth": {
-												"type": "bearer",
-												"bearer": [{
-													"key": "token",
-													"value": "{{BEARER_TOKEN}}",
-													"type": "string"
-												}]
-											},
-											"method": "POST",
-											"header": [{
-												"key": "Accept",
-												"value": "application/vnd.interoperability.transfers+json;version=1"
-											},
-												{
-													"key": "Content-Type",
-													"value": "application/vnd.interoperability.transfers+json;version=1"
-												},
-												{
-													"key": "Date",
-													"value": "{{dateHeader}}"
-												},
-												{
-													"key": "FSPIOP-Source",
-													"value": "{{payerfsp}}"
-												},
-												{
-													"key": "FSPIOP-Destination",
-													"value": "noresponsepayeefsp"
-												},
-												{
-													"key": "FSPIOP-Signature",
-													"value": "{{fspiop-signature}}",
-													"type": "text"
-												}
-											],
-											"body": {
-												"mode": "raw",
-												"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
-											},
-											"url": {
-												"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-												"host": [
-													"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-												],
-												"path": [
-													"transfers"
-												]
-											}
-										},
-										"response": []
-									},
-									{
-										"name": "Send Fulfill",
-										"event": [{
-											"listen": "prerequest",
-											"script": {
-												"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
-												"exec": [
-													"pm.environment.set(\"completedTimestamp\",new Date().toISOString());"
-												],
-												"type": "text/javascript"
-											}
-										},
-											{
-												"listen": "test",
-												"script": {
-													"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
-													"exec": [
-														"pm.test(\"Status code is 200\", function () {",
-														"    pm.response.to.have.status(200);",
-														"});",
-														"",
-														"setTimeout(function () {",
-														"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-														"          if(response.responseSize !== 0) {",
-														"              //Check headers",
-														"              var headers = response.json().headers;",
-														"              ",
-														"                pm.test(\"fspiop-source is noresponsepayeefsp\", function () {",
-														"                    pm.expect(headers['fspiop-source']).to.eql('noresponsepayeefsp');",
-														"                });",
-														"                ",
-														"                pm.test(\"fspiop-destination is payerfsp\", function () {",
-														"                    pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
-														"                });",
-														"                ",
-														"                //Uncomment after JWS is implemented",
-														"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
-														"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
-														"                // });",
-														"                ",
-														"                pm.test(\"date header should not be empty\", function () {",
-														"                    pm.expect(headers['date']).to.be.not.empty;",
-														"                });",
-														"                ",
-														"                pm.test(\"accept header should not be sent in the response\", function () {",
-														"                    pm.expect(headers['accept']).to.eql(undefined);",
-														"                });",
-														"                ",
-														"                pm.test(\"payeefsp content-type is same as sent in the request\", function () {",
-														"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-														"                });",
-														"                ",
-														"              //Check data",
-														"              var jsonData = response.json().data;",
-														"              pm.test(\"Response transferState should be COMMITTED\", function () {",
-														"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-														"              });",
-														"              ",
-														"              pm.test(\"Response fulfilment should be same as in request\", function () {",
-														"                pm.expect(jsonData.fulfilment).to.eql(pm.environment.get(\"validFulfillment\"));",
-														"              });",
-														"              ",
-														"          } else {",
-														"              pm.test(\"Transfer FAILED\", function () {",
-														"                throw new Error('Did not receive response');",
-														"              });",
-														"              ",
-														"          }",
-														"   });",
-														"}, 5000)"
-													],
-													"type": "text/javascript"
-												}
-											}
-										],
-										"request": {
-											"auth": {
-												"type": "bearer",
-												"bearer": [{
-													"key": "token",
-													"value": "{{PAYEEFSP_BEARER_TOKEN}}",
-													"type": "string"
-												}]
-											},
-											"method": "PUT",
-											"header": [{
-												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
-												"value": "application/vnd.interoperability.transfers+json;version=1.0"
-											},
-												{
-													"key": "Date",
-													"type": "text",
-													"value": "{{dateHeader}}"
-												},
-												{
-													"key": "FSPIOP-Source",
-													"type": "text",
-													"value": "noresponsepayeefsp"
-												},
-												{
-													"key": "FSPIOP-Destination",
-													"type": "text",
-													"value": "{{payerfsp}}"
-												}
-											],
-											"body": {
-												"mode": "raw",
-												"raw": "{\n  \"fulfilment\": \"{{validFulfillment}}\",\n  \"completedTimestamp\": \"{{completedTimestamp}}\",\n  \"transferState\": \"COMMITTED\"\n}"
-											},
-											"url": {
-												"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
-												"host": [
-													"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-												],
-												"path": [
-													"transfers",
-													"{{transfer_ID}}"
-												]
-											}
-										},
-										"response": []
-									},
-									{
-										"name": "Send Invalid Duplicate Fulfill",
-										"event": [{
-											"listen": "prerequest",
-											"script": {
-												"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
-												"exec": [
-													"pm.variables.set(\"updatedTimestamp\",new Date().toISOString());"
-												],
-												"type": "text/javascript"
-											}
-										},
-											{
-												"listen": "test",
-												"script": {
-													"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
-													"exec": [
-														"pm.test(\"Status code is 200\", function () {",
-														"    pm.response.to.have.status(200);",
-														"});",
-														"",
-														"setTimeout(function () {",
-														"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/noresponsepayeefsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-														"          if(response.responseSize !== 0) {",
-														"              ",
-														"              //Check headers",
-														"              var headers = response.json().headers;",
-														"              ",
-														"                pm.test(\"fspiop-source is switch\", function () {",
-														"                    pm.expect(headers['fspiop-source']).to.eql('switch');",
-														"                });",
-														"                ",
-														"                pm.test(\"fspiop-destination is noresponsepayeefsp\", function () {",
-														"                    pm.expect(headers['fspiop-destination']).to.eql('noresponsepayeefsp');",
-														"                });",
-														"                ",
-														"                //Uncomment after JWS is implemented",
-														"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
-														"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
-														"                // });",
-														"                pm.test(\"date header should not be empty\", function () {",
-														"                    pm.expect(headers['date']).to.be.not.empty;",
-														"                });",
-														"                ",
-														"                pm.test(\"accept header should not be sent in the response\", function () {",
-														"                    pm.expect(headers['accept']).to.eql(undefined);",
-														"                });",
-														"                ",
-														"                pm.test(\"content-type is same as sent in the request\", function () {",
-														"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-														"                });",
-														"                ",
-														"                ",
-														"             //Check data    ",
-														"              var jsonData = response.json().data;",
-														"              ",
-														"              pm.test(\"Response Error Code is 3106\", function () {",
-														"                pm.expect(jsonData.errorInformation.errorCode).to.eql('3106');",
-														"              });",
-														"              ",
-														"              pm.test(\"Response Error Desription is 'Modified request'\", function () {",
-														"                pm.expect(jsonData.errorInformation.errorDescription).to.eql('Modified request');",
-														"              });",
-														"          } else {",
-														"              pm.test(\"Transfer FAILED\", function () {",
-														"                throw new Error('Did not receive response');",
-														"              });",
-														"              ",
-														"          }",
-														"   });",
-														"}, 5000)"
-													],
-													"type": "text/javascript"
-												}
-											}
-										],
-										"request": {
-											"auth": {
-												"type": "bearer",
-												"bearer": [{
-													"key": "token",
-													"value": "{{PAYEEFSP_BEARER_TOKEN}}",
-													"type": "string"
-												}]
-											},
-											"method": "PUT",
-											"header": [{
-												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
-												"value": "application/vnd.interoperability.transfers+json;version=1.0"
-											},
-												{
-													"key": "Date",
-													"type": "text",
-													"value": "{{dateHeader}}"
-												},
-												{
-													"key": "FSPIOP-Source",
-													"type": "text",
-													"value": "noresponsepayeefsp"
-												},
-												{
-													"key": "FSPIOP-Destination",
-													"type": "text",
-													"value": "{{payerfsp}}"
-												}
-											],
-											"body": {
-												"mode": "raw",
-												"raw": "{\n  \"fulfilment\": \"{{validFulfillment}}\",\n  \"completedTimestamp\": \"{{updatedTimestamp}}\",\n  \"transferState\": \"COMMITTED\"\n}"
-											},
-											"url": {
-												"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
-												"host": [
-													"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-												],
-												"path": [
-													"transfers",
-													"{{transfer_ID}}"
-												]
-											}
-										},
-										"response": []
-									}
-								],
-								"_postman_isSubFolder": true
-							}
-						],
-						"description": "Send a transfer-prepare from payerfsp to payeefsp\nDo not send transfer-fulfil from payeefsp.\n\nSend a duplicate transfer-prepare with same params.\ncheck the simulator logs to make sure that there should not be any response for the duplicate transfer when the actual transfer is not at terminal state which means neither committed nor aborted but in process.\n\nThis is same as sending duplicate transfer when actual transfer is at ABORTED state.",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "eb820baa-0cb0-4c41-9955-8f96395d68a6",
-								"type": "text/javascript",
-								"exec": [
-									""
-								]
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "61fcc61f-21fc-4b4f-b320-c64702d73893",
-									"type": "text/javascript",
-									"exec": [
-										""
-									]
-								}
-							}
-						],
-						"_postman_isSubFolder": true
-					},
-					{
-						"name": "fulfill_reject",
-						"item": [{
-							"name": "positive",
-							"item": [{
-								"name": "Send Quote",
-								"event": [{
-									"listen": "prerequest",
-									"script": {
-										"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-										"exec": [
-											"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-											"   var uuid = require('uuid');",
-											"   var generatedUUID = uuid.v4();",
-											"   pm.variables.set('quoteId', generatedUUID);",
-											"}",
-											"",
-											"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-											"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								},
-									{
-										"listen": "test",
-										"script": {
-											"id": "b7ca6bc0-b58a-46d8-8881-2db1aa0703ef",
-											"exec": [
-												"pm.test(\"Status code is 202\", function () {",
-												"    pm.response.to.have.status(202);",
-												"});",
-												"",
-												"// pm.test(\"Check that Content-Type is present\", function () {",
-												"//     pm.response.to.have.header(\"Content-Type\");",
-												"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.quotes+json;version=1.0\");",
-												"// });",
-												"",
-												"",
-												"setTimeout(function () {",
-												"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-												"      if(response.responseSize !== 0) {",
-												"          console.log('response: ',response.json());",
-												"       pm.test(\"Response ilpPacket is not undefined\", function () {",
-												"           console.log('ilpPacket: ',response.json().ilpPacket)",
-												"           pm.expect(response.json().ilpPacket).not.eql(undefined);",
-												"          pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
-												"           ",
-												"       });",
-												"       ",
-												"       pm.test(\"Response condition is not undefined\", function () {",
-												"           pm.expect(response.json().condition).not.eql(undefined);",
-												"           pm.environment.set(\"condition\", response.json().condition);",
-												"       });",
-												"      } else {",
-												"          pm.test(\"Quote FAILED\", function () {",
-												"            throw new Error('Did not receive response');",
-												"           });",
-												"",
-												"      }",
-												"       ",
-												"   });",
-												"}, 1000)",
-												"",
-												"",
-												""
-											],
-											"type": "text/javascript"
-										}
-									}
-								],
-								"request": {
-									"method": "POST",
-									"header": [{
-										"key": "Accept",
-										"value": "application/vnd.interoperability.quotes+json;version=1"
-									},
-										{
-											"key": "Content-Type",
-											"value": "application/vnd.interoperability.quotes+json;version=1.0"
-										},
-										{
-											"key": "Date",
-											"value": "{{quoteDate}}"
-										},
-										{
-											"key": "FSPIOP-SOurce",
-											"value": "{{payerfsp}}"
-										},
-										{
-											"key": "FSPIOP-Destination",
-											"value": "{{payeefsp}}"
-										}
-									],
-									"body": {
-										"mode": "raw",
-										"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{quoteId}}\",\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"{{receiverMSISDN}}\",\n      \"fspId\": \"{{payeefsp}}\"\n    }\n  },\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"27713803905\",\n      \"fspId\": \"{{payerfsp}}\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
-									},
-									"url": {
-										"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
-										"host": [
-											"{{HOST_QUOTING_SERVICE}}"
-										],
-										"path": [
-											"quotes"
-										]
-									}
-								},
-								"response": []
-							},
-								{
-									"name": "Send Transfer-Prepare",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-											"exec": [
-												"",
-												"var uuid = require('uuid');",
-												"var generatedUUID = uuid.v4();",
-												"pm.environment.set('transfer_ID', generatedUUID);",
-												"pm.environment.set('transferDate', (new Date()).toUTCString());",
-												"pm.environment.set('transferAmount', 100);",
-												"",
-												"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
-												"exec": [
-													"pm.test(\"Status code is 202\", function () {",
-													"    pm.response.to.have.status(202);",
-													"});",
-													"",
-													"",
-													"",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
 										}
 									],
 									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
 										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.transfers+json;version=1"
-										},
+										"header": [
 											{
-												"key": "Content-Type",
+												"key": "Accept",
 												"value": "application/vnd.interoperability.transfers+json;version=1"
 											},
 											{
+												"key": "Content-Type",
+												"value": "application/vnd.interoperability.transfers+json;version=1.0"
+											},
+											{
 												"key": "Date",
-												"value": "{{dateHeader}}"
+												"value": "{{transferDate}}"
 											},
 											{
 												"key": "FSPIOP-Source",
@@ -9578,17 +8468,12 @@
 											},
 											{
 												"key": "FSPIOP-Destination",
-												"value": "noresponsepayeefsp"
-											},
-											{
-												"key": "FSPIOP-Signature",
-												"value": "{{fspiop-signature}}",
-												"type": "text"
+												"value": "{{payeefsp}}"
 											}
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
+											"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"{{payeefsp}}\",\n  \"amount\": {\n    \"amount\": \"1\",\n    \"currency\": \"USD\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
 										},
 										"url": {
 											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
@@ -9603,283 +8488,12 @@
 									"response": []
 								},
 								{
-									"name": "Send Fulfill-Reject",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
-											"exec": [
-												"pm.environment.set(\"completedTimestamp\",new Date().toISOString());"
-											],
-											"type": "text/javascript"
-										}
-									},
+									"name": "Duplicate Transfer",
+									"event": [
 										{
 											"listen": "test",
 											"script": {
-												"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
-												"exec": [
-													"pm.test(\"Status code is 200\", function () {",
-													"    pm.response.to.have.status(200);",
-													"});",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-													"          if(response.responseSize !== 0) {",
-													"              //Check headers",
-													"              var headers = response.json().headers;",
-													"              ",
-													"                pm.test(\"fspiop-source is noresponsepayeefsp\", function () {",
-													"                    pm.expect(headers['fspiop-source']).to.eql('noresponsepayeefsp');",
-													"                });",
-													"                ",
-													"                pm.test(\"fspiop-destination is payerfsp\", function () {",
-													"                    pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
-													"                });",
-													"                ",
-													"                //Uncomment after JWS is implemented",
-													"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
-													"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
-													"                // });",
-													"                ",
-													"                pm.test(\"date header should not be empty\", function () {",
-													"                    pm.expect(headers['date']).to.be.not.empty;",
-													"                });",
-													"                ",
-													"                pm.test(\"accept header should not be sent in the response\", function () {",
-													"                    pm.expect(headers['accept']).to.eql(undefined);",
-													"                });",
-													"                ",
-													"                pm.test(\"payeefsp content-type is same as sent in the request\", function () {",
-													"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-													"                });",
-													"                ",
-													"              //Check data",
-													"              var jsonData = response.json().data;",
-													"              pm.test(\"Response Error Code is 5101\", function () {",
-													"                pm.expect(jsonData.errorInformation.errorCode).to.eql('5101');",
-													"              });",
-													"              ",
-													"              pm.test(\"Response Error Desription is 'Payee transaction limit reached'\", function () {",
-													"                pm.expect(jsonData.errorInformation.errorDescription).to.eql('Payee transaction limit reached');",
-													"              });",
-													"              ",
-													"          } else {",
-													"              pm.test(\"Transfer FAILED\", function () {",
-													"                throw new Error('Did not receive response');",
-													"              });",
-													"",
-													"          }",
-													"   });",
-													"}, 5000)"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{PAYEEFSP_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "PUT",
-										"header": [{
-											"key": "Content-Type",
-											"name": "Content-Type",
-											"type": "text",
-											"value": "application/vnd.interoperability.transfers+json;version=1.0"
-										},
-											{
-												"key": "Date",
-												"type": "text",
-												"value": "{{dateHeader}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"type": "text",
-												"value": "noresponsepayeefsp"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"type": "text",
-												"value": "{{payerfsp}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n\t\"errorInformation\": {\n\t\t\"errorCode\": \"5101\",\n\t\t\"errorDescription\": \"Payee transaction limit reached\",\n\t\t\"extensionList\": {\n\t\t\t\"extension\": [{\n\t\t\t\t\"key\": \"errorDetail\",\n\t\t\t\t\"value\": \"This is an abort extension\"\n\t\t\t}]\n\t\t}\n\t}\n}"
-										},
-										"url": {
-											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}/error",
-											"host": [
-												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-											],
-											"path": [
-												"transfers",
-												"{{transfer_ID}}",
-												"error"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Send Duplicate Fulfill-Reject",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
-											"exec": [
-												""
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
-												"exec": [
-													"pm.test(\"Status code is 200\", function () {",
-													"    pm.response.to.have.status(200);",
-													"});",
-													"",
-													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/noresponsepayeefsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-													"          if(response.responseSize !== 0) {",
-													"              //Check headers",
-													"              var headers = response.json().headers;",
-													"              ",
-													"                pm.test(\"fspiop-source is switch\", function () {",
-													"                    pm.expect(headers['fspiop-source']).to.eql('switch');",
-													"                });",
-													"                ",
-													"                pm.test(\"fspiop-destination is noresponsepayeefsp\", function () {",
-													"                    pm.expect(headers['fspiop-destination']).to.eql('noresponsepayeefsp');",
-													"                });",
-													"                ",
-													"                //Uncomment after JWS is implemented",
-													"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
-													"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
-													"                // });",
-													"                ",
-													"                pm.test(\"date header should not be empty\", function () {",
-													"                    pm.expect(headers['date']).to.be.not.empty;",
-													"                });",
-													"                ",
-													"                pm.test(\"accept header should not be sent in the response\", function () {",
-													"                    pm.expect(headers['accept']).to.eql(undefined);",
-													"                });",
-													"                ",
-													"                pm.test(\"content-type is same as sent in the request\", function () {",
-													"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-													"                });",
-													"                ",
-													"              //Check data",
-													"              var jsonData = response.json().data;",
-													"              pm.test(\"Response transferState should be ABORTED\", function () {",
-													"                pm.expect(jsonData.transferState).to.eql('ABORTED');",
-													"              });",
-													"              ",
-													"              pm.test(\"Response fulfilment should be empty\", function () {",
-													"                pm.expect(jsonData.fulfilment).to.eql(undefined);",
-													"              });",
-													"          } else {",
-													"              pm.test(\"Transfer FAILED\", function () {",
-													"                throw new Error('Did not receive response');",
-													"              });",
-													"",
-													"          }",
-													"   });",
-													"}, 5000)"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [{
-												"key": "token",
-												"value": "{{PAYEEFSP_BEARER_TOKEN}}",
-												"type": "string"
-											}]
-										},
-										"method": "PUT",
-										"header": [{
-											"key": "Content-Type",
-											"name": "Content-Type",
-											"type": "text",
-											"value": "application/vnd.interoperability.transfers+json;version=1.0"
-										},
-											{
-												"key": "Date",
-												"type": "text",
-												"value": "{{dateHeader}}"
-											},
-											{
-												"key": "FSPIOP-Source",
-												"type": "text",
-												"value": "noresponsepayeefsp"
-											},
-											{
-												"key": "FSPIOP-Destination",
-												"type": "text",
-												"value": "{{payerfsp}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n\t\"errorInformation\": {\n\t\t\"errorCode\": \"5101\",\n\t\t\"errorDescription\": \"Payee transaction limit reached\",\n\t\t\"extensionList\": {\n\t\t\t\"extension\": [{\n\t\t\t\t\"key\": \"errorDetail\",\n\t\t\t\t\"value\": \"This is an abort extension\"\n\t\t\t}]\n\t\t}\n\t}\n}"
-										},
-										"url": {
-											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}/error",
-											"host": [
-												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-											],
-											"path": [
-												"transfers",
-												"{{transfer_ID}}",
-												"error"
-											]
-										}
-									},
-									"response": []
-								}
-							],
-							"_postman_isSubFolder": true
-						},
-							{
-								"name": "negative",
-								"item": [{
-									"name": "Send Quote",
-									"event": [{
-										"listen": "prerequest",
-										"script": {
-											"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-											"exec": [
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-												"   var uuid = require('uuid');",
-												"   var generatedUUID = uuid.v4();",
-												"   pm.variables.set('quoteId', generatedUUID);",
-												"}",
-												"",
-												"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-												"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-												"}"
-											],
-											"type": "text/javascript"
-										}
-									},
-										{
-											"listen": "test",
-											"script": {
-												"id": "b7ca6bc0-b58a-46d8-8881-2db1aa0703ef",
+												"id": "900142b0-e4d7-43a4-a751-38202b600661",
 												"exec": [
 													"pm.test(\"Status code is 202\", function () {",
 													"    pm.response.to.have.status(202);",
@@ -9887,36 +8501,46 @@
 													"",
 													"// pm.test(\"Check that Content-Type is present\", function () {",
 													"//     pm.response.to.have.header(\"Content-Type\");",
-													"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.quotes+json;version=1.0\");",
+													"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.transfers+json;version=1.0\");",
 													"// });",
 													"",
-													"",
 													"setTimeout(function () {",
-													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
-													"      if(response.responseSize !== 0) {",
-													"          console.log('response: ',response.json());",
-													"       pm.test(\"Response ilpPacket is not undefined\", function () {",
-													"           console.log('ilpPacket: ',response.json().ilpPacket)",
-													"           pm.expect(response.json().ilpPacket).not.eql(undefined);",
-													"          pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
-													"           ",
-													"       });",
-													"       ",
-													"       pm.test(\"Response condition is not undefined\", function () {",
-													"           pm.expect(response.json().condition).not.eql(undefined);",
-													"           pm.environment.set(\"condition\", response.json().condition);",
-													"       });",
-													"      } else {",
-													"          pm.test(\"Quote FAILED\", function () {",
-													"            throw new Error('Did not receive response');",
-													"           });",
-													"",
-													"      }",
-													"       ",
+													"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.variables.get(\"transfer_ID\"), function (err, response) {",
+													"          if(response.responseSize !== 0) {",
+													"              var jsonData = response.json().data;",
+													"              var headers = response.json().headers",
+													"              pm.test(\"Response data does not have transferId\", function () {",
+													"               pm.expect(jsonData.transferId).to.eql(undefined);",
+													"             });",
+													"              pm.test(\"Response status is COMMITTED\", function () {",
+													"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+													"              });",
+													"              pm.test(\"fspiop-source is switch\", function () {",
+													"                pm.expect(headers['fspiop-source']).to.eql('switch');",
+													"              });",
+													"              pm.test(\"fspiop-destination is payerfsp\", function () {",
+													"                pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
+													"              });",
+													"          } else {",
+													"              pm.test(\"Transfer FAILED\", function () {",
+													"                throw new Error('Did not receive response');",
+													"              });",
+													"              ",
+													"          }",
 													"   });",
-													"}, 1000)",
+													"}, 2000)",
 													"",
 													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "20820c95-0a24-4906-a6ba-708d6ecf4a61",
+												"exec": [
 													""
 												],
 												"type": "text/javascript"
@@ -9925,20 +8549,21 @@
 									],
 									"request": {
 										"method": "POST",
-										"header": [{
-											"key": "Accept",
-											"value": "application/vnd.interoperability.quotes+json;version=1"
-										},
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/vnd.interoperability.transfers+json;version=1"
+											},
 											{
 												"key": "Content-Type",
-												"value": "application/vnd.interoperability.quotes+json;version=1.0"
+												"value": "application/vnd.interoperability.transfers+json;version=1.0"
 											},
 											{
 												"key": "Date",
-												"value": "{{quoteDate}}"
+												"value": "{{transferDate}}"
 											},
 											{
-												"key": "FSPIOP-SOurce",
+												"key": "FSPIOP-Source",
 												"value": "{{payerfsp}}"
 											},
 											{
@@ -9948,458 +8573,2021 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{quoteId}}\",\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"{{receiverMSISDN}}\",\n      \"fspId\": \"{{payeefsp}}\"\n    }\n  },\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"27713803905\",\n      \"fspId\": \"{{payerfsp}}\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+											"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"{{payeefsp}}\",\n  \"amount\": {\n    \"amount\": \"1\",\n    \"currency\": \"USD\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{condition}}\"\n}"
 										},
 										"url": {
-											"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+											"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
 											"host": [
-												"{{HOST_QUOTING_SERVICE}}"
+												"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
 											],
 											"path": [
-												"quotes"
+												"transfers"
 											]
 										}
 									},
 									"response": []
-								},
-									{
-										"name": "Send Transfer-Prepare",
-										"event": [{
-											"listen": "prerequest",
-											"script": {
-												"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
-												"exec": [
-													"",
-													"var uuid = require('uuid');",
-													"var generatedUUID = uuid.v4();",
-													"pm.environment.set('transfer_ID', generatedUUID);",
-													"pm.environment.set('transferDate', (new Date()).toUTCString());",
-													"pm.environment.set('transferAmount', 100);",
-													"",
-													"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
-												],
-												"type": "text/javascript"
-											}
-										},
-											{
-												"listen": "test",
-												"script": {
-													"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
-													"exec": [
-														"pm.test(\"Status code is 202\", function () {",
-														"    pm.response.to.have.status(202);",
-														"});",
-														"",
-														"",
-														"",
-														"",
-														""
-													],
-													"type": "text/javascript"
-												}
-											}
-										],
-										"request": {
-											"auth": {
-												"type": "bearer",
-												"bearer": [{
-													"key": "token",
-													"value": "{{BEARER_TOKEN}}",
-													"type": "string"
-												}]
-											},
-											"method": "POST",
-											"header": [{
-												"key": "Accept",
-												"value": "application/vnd.interoperability.transfers+json;version=1"
-											},
-												{
-													"key": "Content-Type",
-													"value": "application/vnd.interoperability.transfers+json;version=1"
-												},
-												{
-													"key": "Date",
-													"value": "{{dateHeader}}"
-												},
-												{
-													"key": "FSPIOP-Source",
-													"value": "{{payerfsp}}"
-												},
-												{
-													"key": "FSPIOP-Destination",
-													"value": "noresponsepayeefsp"
-												},
-												{
-													"key": "FSPIOP-Signature",
-													"value": "{{fspiop-signature}}",
-													"type": "text"
-												}
-											],
-											"body": {
-												"mode": "raw",
-												"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
-											},
-											"url": {
-												"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
-												"host": [
-													"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-												],
-												"path": [
-													"transfers"
-												]
-											}
-										},
-										"response": []
-									},
-									{
-										"name": "Send Fulfill-Reject",
-										"event": [{
-											"listen": "prerequest",
-											"script": {
-												"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
-												"exec": [
-													"pm.environment.set(\"completedTimestamp\",new Date().toISOString());"
-												],
-												"type": "text/javascript"
-											}
-										},
-											{
-												"listen": "test",
-												"script": {
-													"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
-													"exec": [
-														"pm.test(\"Status code is 200\", function () {",
-														"    pm.response.to.have.status(200);",
-														"});",
-														"",
-														"setTimeout(function () {",
-														"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-														"          if(response.responseSize !== 0) {",
-														"              //Check headers",
-														"              var headers = response.json().headers;",
-														"              ",
-														"                pm.test(\"fspiop-source is noresponsepayeefsp\", function () {",
-														"                    pm.expect(headers['fspiop-source']).to.eql('noresponsepayeefsp');",
-														"                });",
-														"                ",
-														"                pm.test(\"fspiop-destination is payerfsp\", function () {",
-														"                    pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
-														"                });",
-														"                ",
-														"                //Uncomment after JWS is implemented",
-														"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
-														"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
-														"                // });",
-														"                ",
-														"                ",
-														"                pm.test(\"payeefsp content-type is same as sent in the request\", function () {",
-														"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-														"                });",
-														"                ",
-														"                pm.test(\"date header should not be empty\", function () {",
-														"                    pm.expect(headers['date']).to.be.not.empty;",
-														"                });",
-														"                ",
-														"                pm.test(\"accept header should not be sent in the response\", function () {",
-														"                    pm.expect(headers['accept']).to.eql(undefined);",
-														"                });",
-														"                ",
-														"              //Check data",
-														"              var jsonData = response.json().data;",
-														"              pm.test(\"Response Error Code is 5101\", function () {",
-														"                pm.expect(jsonData.errorInformation.errorCode).to.eql('5101');",
-														"              });",
-														"              ",
-														"              pm.test(\"Response Error Desription is 'Payee transaction limit reached'\", function () {",
-														"                pm.expect(jsonData.errorInformation.errorDescription).to.eql('Payee transaction limit reached');",
-														"              });",
-														"              ",
-														"          } else {",
-														"              pm.test(\"Transfer FAILED\", function () {",
-														"                throw new Error('Did not receive response');",
-														"              });",
-														"              ",
-														"          }",
-														"   });",
-														"}, 5000)"
-													],
-													"type": "text/javascript"
-												}
-											}
-										],
-										"request": {
-											"auth": {
-												"type": "bearer",
-												"bearer": [{
-													"key": "token",
-													"value": "{{PAYEEFSP_BEARER_TOKEN}}",
-													"type": "string"
-												}]
-											},
-											"method": "PUT",
-											"header": [{
-												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
-												"value": "application/vnd.interoperability.transfers+json;version=1.0"
-											},
-												{
-													"key": "Date",
-													"type": "text",
-													"value": "{{dateHeader}}"
-												},
-												{
-													"key": "FSPIOP-Source",
-													"type": "text",
-													"value": "noresponsepayeefsp"
-												},
-												{
-													"key": "FSPIOP-Destination",
-													"type": "text",
-													"value": "{{payerfsp}}"
-												}
-											],
-											"body": {
-												"mode": "raw",
-												"raw": "{\n\t\"errorInformation\": {\n\t\t\"errorCode\": \"5101\",\n\t\t\"errorDescription\": \"Payee transaction limit reached\",\n\t\t\"extensionList\": {\n\t\t\t\"extension\": [{\n\t\t\t\t\"key\": \"errorDetail\",\n\t\t\t\t\"value\": \"This is an abort extension\"\n\t\t\t}]\n\t\t}\n\t}\n}"
-											},
-											"url": {
-												"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}/error",
-												"host": [
-													"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-												],
-												"path": [
-													"transfers",
-													"{{transfer_ID}}",
-													"error"
-												]
-											}
-										},
-										"response": []
-									},
-									{
-										"name": "Send Invalid Duplicate Fulfill-Reject",
-										"event": [{
-											"listen": "prerequest",
-											"script": {
-												"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
-												"exec": [
-													""
-												],
-												"type": "text/javascript"
-											}
-										},
-											{
-												"listen": "test",
-												"script": {
-													"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
-													"exec": [
-														"pm.test(\"Status code is 200\", function () {",
-														"    pm.response.to.have.status(200);",
-														"});",
-														"",
-														"setTimeout(function () {",
-														"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/noresponsepayeefsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-														"          if(response.responseSize !== 0) {",
-														"              //Check headers",
-														"              var headers = response.json().headers;",
-														"              ",
-														"                pm.test(\"fspiop-source is switch\", function () {",
-														"                    pm.expect(headers['fspiop-source']).to.eql('switch');",
-														"                });",
-														"                ",
-														"                pm.test(\"fspiop-destination is noresponsepayeefsp\", function () {",
-														"                    pm.expect(headers['fspiop-destination']).to.eql('noresponsepayeefsp');",
-														"                });",
-														"                ",
-														"                //Uncomment after JWS is implemented",
-														"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
-														"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
-														"                // });",
-														"                pm.test(\"date header should not be empty\", function () {",
-														"                    pm.expect(headers['date']).to.be.not.empty;",
-														"                });",
-														"                ",
-														"                pm.test(\"accept header should not be sent in the response\", function () {",
-														"                    pm.expect(headers['accept']).to.eql(undefined);",
-														"                });",
-														"                ",
-														"                pm.test(\"content-type is same as sent in the request\", function () {",
-														"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-														"                });",
-														"                ",
-														"              //Check data",
-														"              var jsonData = response.json().data;",
-														"              pm.test(\"Response Error Code is '3106'\", function () {",
-														"                pm.expect(jsonData.errorInformation.errorCode).to.eql('3106');",
-														"              });",
-														"              ",
-														"              pm.test(\"Response Error Desription is 'Modified request'\", function () {",
-														"                pm.expect(jsonData.errorInformation.errorDescription).to.eql('Modified request');",
-														"              });",
-														"              ",
-														"          } else {",
-														"              pm.test(\"Transfer FAILED\", function () {",
-														"                throw new Error('Did not receive response');",
-														"              });",
-														"",
-														"          }",
-														"   });",
-														"}, 5000)"
-													],
-													"type": "text/javascript"
-												}
-											}
-										],
-										"request": {
-											"auth": {
-												"type": "bearer",
-												"bearer": [{
-													"key": "token",
-													"value": "{{PAYEEFSP_BEARER_TOKEN}}",
-													"type": "string"
-												}]
-											},
-											"method": "PUT",
-											"header": [{
-												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
-												"value": "application/vnd.interoperability.transfers+json;version=1.0"
-											},
-												{
-													"key": "Date",
-													"type": "text",
-													"value": "{{dateHeader}}"
-												},
-												{
-													"key": "FSPIOP-Source",
-													"type": "text",
-													"value": "noresponsepayeefsp"
-												},
-												{
-													"key": "FSPIOP-Destination",
-													"type": "text",
-													"value": "{{payerfsp}}"
-												}
-											],
-											"body": {
-												"mode": "raw",
-												"raw": "{\n\t\"errorInformation\": {\n\t\t\"errorCode\": \"5101\",\n\t\t\"errorDescription\": \"This is an invalid duplicate request\",\n\t\t\"extensionList\": {\n\t\t\t\"extension\": [{\n\t\t\t\t\"key\": \"errorDetail\",\n\t\t\t\t\"value\": \"This is an abort extension\"\n\t\t\t}]\n\t\t}\n\t}\n}"
-											},
-											"url": {
-												"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}/error",
-												"host": [
-													"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
-												],
-												"path": [
-													"transfers",
-													"{{transfer_ID}}",
-													"error"
-												]
-											}
-										},
-										"response": []
-									}
-								],
-								"_postman_isSubFolder": true
-							}
-						],
-						"description": "Send a transfer-prepare from payerfsp to payeefsp\nDo not send transfer-fulfil from payeefsp.\n\nSend a duplicate transfer-prepare with same params.\ncheck the simulator logs to make sure that there should not be any response for the duplicate transfer when the actual transfer is not at terminal state which means neither committed nor aborted but in process.\n\nThis is same as sending duplicate transfer when actual transfer is at ABORTED state.",
-						"event": [{
-							"listen": "prerequest",
-							"script": {
-								"id": "eb820baa-0cb0-4c41-9955-8f96395d68a6",
-								"type": "text/javascript",
-								"exec": [
-									""
-								]
-							}
-						},
-							{
-								"listen": "test",
-								"script": {
-									"id": "61fcc61f-21fc-4b4f-b320-c64702d73893",
-									"type": "text/javascript",
-									"exec": [
-										""
-									]
 								}
-							}
-						],
-						"_postman_isSubFolder": true
-					}
-				],
-				"_postman_isSubFolder": true
-			}]
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "fulfill_commit",
+							"item": [
+								{
+									"name": "positive",
+									"item": [
+										{
+											"name": "Send Quote",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+														"exec": [
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.variables.set('quoteId', generatedUUID);",
+															"}",
+															"",
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+															"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+															"}"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "b7ca6bc0-b58a-46d8-8881-2db1aa0703ef",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.test(\"Check that Content-Type is present\", function () {",
+															"//     pm.response.to.have.header(\"Content-Type\");",
+															"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.quotes+json;version=1.0\");",
+															"// });",
+															"",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
+															"      if(response.responseSize !== 0) {",
+															"          console.log('response: ',response.json());",
+															"       pm.test(\"Response ilpPacket is not undefined\", function () {",
+															"           console.log('ilpPacket: ',response.json().ilpPacket)",
+															"           pm.expect(response.json().ilpPacket).not.eql(undefined);",
+															"          pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
+															"           ",
+															"       });",
+															"       ",
+															"       pm.test(\"Response condition is not undefined\", function () {",
+															"           pm.expect(response.json().condition).not.eql(undefined);",
+															"           pm.environment.set(\"condition\", response.json().condition);",
+															"       });",
+															"      } else {",
+															"          pm.test(\"Quote FAILED\", function () {",
+															"            throw new Error('Did not receive response');",
+															"           });",
+															"",
+															"      }",
+															"       ",
+															"   });",
+															"}, 1000)",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.quotes+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.quotes+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"value": "{{quoteDate}}"
+													},
+													{
+														"key": "FSPIOP-SOurce",
+														"value": "{{payerfsp}}"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "{{payeefsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{quoteId}}\",\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"{{receiverMSISDN}}\",\n      \"fspId\": \"{{payeefsp}}\"\n    }\n  },\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"27713803905\",\n      \"fspId\": \"{{payerfsp}}\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+													"host": [
+														"{{HOST_QUOTING_SERVICE}}"
+													],
+													"path": [
+														"quotes"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Transfer-Prepare",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+														"exec": [
+															"",
+															"var uuid = require('uuid');",
+															"var generatedUUID = uuid.v4();",
+															"pm.environment.set('transfer_ID', generatedUUID);",
+															"pm.environment.set('transferDate', (new Date()).toUTCString());",
+															"pm.environment.set('transferAmount', 100);",
+															"",
+															"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 60000))"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Date",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "{{payerfsp}}"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Signature",
+														"value": "{{fspiop-signature}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Fulfill",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
+														"exec": [
+															"pm.environment.set(\"completedTimestamp\",new Date().toISOString());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"          if(response.responseSize !== 0) {",
+															"              //Check headers",
+															"              var headers = response.json().headers;",
+															"              ",
+															"                pm.test(\"fspiop-source is noresponsepayeefsp\", function () {",
+															"                    pm.expect(headers['fspiop-source']).to.eql('noresponsepayeefsp');",
+															"                });",
+															"                ",
+															"                pm.test(\"fspiop-destination is payerfsp\", function () {",
+															"                    pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
+															"                });",
+															"                ",
+															"                //Uncomment after JWS is implemented",
+															"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
+															"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
+															"                // });",
+															"                ",
+															"                ",
+															"                pm.test(\"payeefsp content-type is same as sent in the request\", function () {",
+															"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+															"                });",
+															"                ",
+															"                pm.test(\"date header should not be empty\", function () {",
+															"                    pm.expect(headers['date']).to.be.not.empty;",
+															"                });",
+															"                ",
+															"                pm.test(\"accept header should not be sent in the response\", function () {",
+															"                    pm.expect(headers['accept']).to.eql(undefined);",
+															"                });",
+															"                ",
+															"              //Check data",
+															"              var jsonData = response.json().data;",
+															"              pm.test(\"Response transferState should be COMMITTED\", function () {",
+															"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+															"              });",
+															"              ",
+															"              pm.test(\"Response fulfilment should be same as in request\", function () {",
+															"                pm.expect(jsonData.fulfilment).to.eql(pm.environment.get(\"validFulfillment\"));",
+															"              });",
+															"              ",
+															"          } else {",
+															"              pm.test(\"Transfer FAILED\", function () {",
+															"                throw new Error('Did not receive response');",
+															"              });",
+															"",
+															"          }",
+															"   });",
+															"}, 5000)"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{PAYEEFSP_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/vnd.interoperability.transfers+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"type": "text",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"type": "text",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"type": "text",
+														"value": "{{payerfsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"fulfilment\": \"{{validFulfillment}}\",\n  \"completedTimestamp\": \"{{completedTimestamp}}\",\n  \"transferState\": \"COMMITTED\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers",
+														"{{transfer_ID}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Duplicate Fulfill",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"// setTimeout(function () {",
+															"//   pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/noresponsepayeefsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"//           if(response.responseSize !== 0) {",
+															"              ",
+															"//               //Check headers",
+															"//               var headers = response.json().headers;",
+															"              ",
+															"//                 pm.test(\"fspiop-source is switch\", function () {",
+															"//                     pm.expect(headers['fspiop-source']).to.eql('switch');",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"fspiop-destination is noresponsepayeefsp\", function () {",
+															"//                     pm.expect(headers['fspiop-destination']).to.eql('noresponsepayeefsp');",
+															"//                 });",
+															"                ",
+															"//                 //Uncomment after JWS is implemented",
+															"//                 // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
+															"//                 //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
+															"//                 // });",
+															"                ",
+															"                ",
+															"//                 pm.test(\" content-type is same as sent in the request\", function () {",
+															"//                     pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"date header should not be empty\", function () {",
+															"//                     pm.expect(headers['date']).to.be.not.empty;",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"accept header should not be sent in the response\", function () {",
+															"//                     pm.expect(headers['accept']).to.eql(undefined);",
+															"//                 });",
+															"                ",
+															"//              //Check data    ",
+															"//               var jsonData = response.json().data;",
+															"//               pm.test(\"Response transferState should be COMMITTED\", function () {",
+															"//                 pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+															"//               });",
+															"              ",
+															"//               pm.test(\"Response fulfilment should be same as in request\", function () {",
+															"//                 pm.expect(jsonData.fulfilment).to.eql(pm.environment.get(\"validFulfillment\"));",
+															"//               });",
+															"//           } else {",
+															"//               pm.test(\"Transfer FAILED\", function () {",
+															"//                 throw new Error('Did not receive response');",
+															"//               });",
+															"              ",
+															"//           }",
+															"//   });",
+															"// }, 5000)"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{PAYEEFSP_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/vnd.interoperability.transfers+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"type": "text",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"type": "text",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"type": "text",
+														"value": "{{payerfsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"fulfilment\": \"{{validFulfillment}}\",\n  \"completedTimestamp\": \"{{completedTimestamp}}\",\n  \"transferState\": \"COMMITTED\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers",
+														"{{transfer_ID}}"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								},
+								{
+									"name": "negative",
+									"item": [
+										{
+											"name": "Send Quote",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+														"exec": [
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.variables.set('quoteId', generatedUUID);",
+															"}",
+															"",
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+															"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+															"}"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "b7ca6bc0-b58a-46d8-8881-2db1aa0703ef",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.test(\"Check that Content-Type is present\", function () {",
+															"//     pm.response.to.have.header(\"Content-Type\");",
+															"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.quotes+json;version=1.0\");",
+															"// });",
+															"",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
+															"      if(response.responseSize !== 0) {",
+															"          console.log('response: ',response.json());",
+															"       pm.test(\"Response ilpPacket is not undefined\", function () {",
+															"           console.log('ilpPacket: ',response.json().ilpPacket)",
+															"           pm.expect(response.json().ilpPacket).not.eql(undefined);",
+															"          pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
+															"           ",
+															"       });",
+															"       ",
+															"       pm.test(\"Response condition is not undefined\", function () {",
+															"           pm.expect(response.json().condition).not.eql(undefined);",
+															"           pm.environment.set(\"condition\", response.json().condition);",
+															"       });",
+															"      } else {",
+															"          pm.test(\"Quote FAILED\", function () {",
+															"            throw new Error('Did not receive response');",
+															"           });",
+															"",
+															"      }",
+															"       ",
+															"   });",
+															"}, 1000)",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.quotes+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.quotes+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"value": "{{quoteDate}}"
+													},
+													{
+														"key": "FSPIOP-SOurce",
+														"value": "{{payerfsp}}"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "{{payeefsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{quoteId}}\",\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"{{receiverMSISDN}}\",\n      \"fspId\": \"{{payeefsp}}\"\n    }\n  },\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"27713803905\",\n      \"fspId\": \"{{payerfsp}}\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+													"host": [
+														"{{HOST_QUOTING_SERVICE}}"
+													],
+													"path": [
+														"quotes"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Transfer-Prepare",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+														"exec": [
+															"",
+															"var uuid = require('uuid');",
+															"var generatedUUID = uuid.v4();",
+															"pm.environment.set('transfer_ID', generatedUUID);",
+															"pm.environment.set('transferDate', (new Date()).toUTCString());",
+															"pm.environment.set('transferAmount', 100);",
+															"",
+															"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 60000))"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Date",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "{{payerfsp}}"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Signature",
+														"value": "{{fspiop-signature}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Fulfill",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
+														"exec": [
+															"pm.environment.set(\"completedTimestamp\",new Date().toISOString());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"          if(response.responseSize !== 0) {",
+															"              //Check headers",
+															"              var headers = response.json().headers;",
+															"              ",
+															"                pm.test(\"fspiop-source is noresponsepayeefsp\", function () {",
+															"                    pm.expect(headers['fspiop-source']).to.eql('noresponsepayeefsp');",
+															"                });",
+															"                ",
+															"                pm.test(\"fspiop-destination is payerfsp\", function () {",
+															"                    pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
+															"                });",
+															"                ",
+															"                //Uncomment after JWS is implemented",
+															"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
+															"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
+															"                // });",
+															"                ",
+															"                pm.test(\"date header should not be empty\", function () {",
+															"                    pm.expect(headers['date']).to.be.not.empty;",
+															"                });",
+															"                ",
+															"                pm.test(\"accept header should not be sent in the response\", function () {",
+															"                    pm.expect(headers['accept']).to.eql(undefined);",
+															"                });",
+															"                ",
+															"                pm.test(\"payeefsp content-type is same as sent in the request\", function () {",
+															"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+															"                });",
+															"                ",
+															"              //Check data",
+															"              var jsonData = response.json().data;",
+															"              pm.test(\"Response transferState should be COMMITTED\", function () {",
+															"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+															"              });",
+															"              ",
+															"              pm.test(\"Response fulfilment should be same as in request\", function () {",
+															"                pm.expect(jsonData.fulfilment).to.eql(pm.environment.get(\"validFulfillment\"));",
+															"              });",
+															"              ",
+															"          } else {",
+															"              pm.test(\"Transfer FAILED\", function () {",
+															"                throw new Error('Did not receive response');",
+															"              });",
+															"              ",
+															"          }",
+															"   });",
+															"}, 5000)"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{PAYEEFSP_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/vnd.interoperability.transfers+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"type": "text",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"type": "text",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"type": "text",
+														"value": "{{payerfsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"fulfilment\": \"{{validFulfillment}}\",\n  \"completedTimestamp\": \"{{completedTimestamp}}\",\n  \"transferState\": \"COMMITTED\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers",
+														"{{transfer_ID}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Invalid Duplicate Fulfill",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
+														"exec": [
+															"pm.variables.set(\"updatedTimestamp\",new Date().toISOString());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"// setTimeout(function () {",
+															"//   pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/noresponsepayeefsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"//           if(response.responseSize !== 0) {",
+															"              ",
+															"//               //Check headers",
+															"//               var headers = response.json().headers;",
+															"              ",
+															"//                 pm.test(\"fspiop-source is switch\", function () {",
+															"//                     pm.expect(headers['fspiop-source']).to.eql('switch');",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"fspiop-destination is noresponsepayeefsp\", function () {",
+															"//                     pm.expect(headers['fspiop-destination']).to.eql('noresponsepayeefsp');",
+															"//                 });",
+															"                ",
+															"//                 //Uncomment after JWS is implemented",
+															"//                 // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
+															"//                 //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
+															"//                 // });",
+															"//                 pm.test(\"date header should not be empty\", function () {",
+															"//                     pm.expect(headers['date']).to.be.not.empty;",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"accept header should not be sent in the response\", function () {",
+															"//                     pm.expect(headers['accept']).to.eql(undefined);",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"content-type is same as sent in the request\", function () {",
+															"//                     pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+															"//                 });",
+															"                ",
+															"                ",
+															"//              //Check data    ",
+															"//               var jsonData = response.json().data;",
+															"              ",
+															"//               pm.test(\"Response Error Code is 3106\", function () {",
+															"//                 pm.expect(jsonData.errorInformation.errorCode).to.eql('3106');",
+															"//               });",
+															"              ",
+															"//               pm.test(\"Response Error Desription is 'Modified request'\", function () {",
+															"//                 pm.expect(jsonData.errorInformation.errorDescription).to.eql('Modified request');",
+															"//               });",
+															"//           } else {",
+															"//               pm.test(\"Transfer FAILED\", function () {",
+															"//                 throw new Error('Did not receive response');",
+															"//               });",
+															"              ",
+															"//           }",
+															"//   });",
+															"// }, 5000)"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{PAYEEFSP_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/vnd.interoperability.transfers+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"type": "text",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"type": "text",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"type": "text",
+														"value": "{{payerfsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"fulfilment\": \"{{validFulfillment}}\",\n  \"completedTimestamp\": \"{{updatedTimestamp}}\",\n  \"transferState\": \"COMMITTED\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers",
+														"{{transfer_ID}}"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								}
+							],
+							"description": "Send a transfer-prepare from payerfsp to payeefsp\nDo not send transfer-fulfil from payeefsp.\n\nSend a duplicate transfer-prepare with same params.\ncheck the simulator logs to make sure that there should not be any response for the duplicate transfer when the actual transfer is not at terminal state which means neither committed nor aborted but in process.\n\nThis is same as sending duplicate transfer when actual transfer is at ABORTED state.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb820baa-0cb0-4c41-9955-8f96395d68a6",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "61fcc61f-21fc-4b4f-b320-c64702d73893",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "fulfill_reject",
+							"item": [
+								{
+									"name": "positive",
+									"item": [
+										{
+											"name": "Send Quote",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+														"exec": [
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.variables.set('quoteId', generatedUUID);",
+															"}",
+															"",
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+															"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+															"}"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "b7ca6bc0-b58a-46d8-8881-2db1aa0703ef",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.test(\"Check that Content-Type is present\", function () {",
+															"//     pm.response.to.have.header(\"Content-Type\");",
+															"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.quotes+json;version=1.0\");",
+															"// });",
+															"",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
+															"      if(response.responseSize !== 0) {",
+															"          console.log('response: ',response.json());",
+															"       pm.test(\"Response ilpPacket is not undefined\", function () {",
+															"           console.log('ilpPacket: ',response.json().ilpPacket)",
+															"           pm.expect(response.json().ilpPacket).not.eql(undefined);",
+															"          pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
+															"           ",
+															"       });",
+															"       ",
+															"       pm.test(\"Response condition is not undefined\", function () {",
+															"           pm.expect(response.json().condition).not.eql(undefined);",
+															"           pm.environment.set(\"condition\", response.json().condition);",
+															"       });",
+															"      } else {",
+															"          pm.test(\"Quote FAILED\", function () {",
+															"            throw new Error('Did not receive response');",
+															"           });",
+															"",
+															"      }",
+															"       ",
+															"   });",
+															"}, 1000)",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.quotes+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.quotes+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"value": "{{quoteDate}}"
+													},
+													{
+														"key": "FSPIOP-SOurce",
+														"value": "{{payerfsp}}"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "{{payeefsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{quoteId}}\",\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"{{receiverMSISDN}}\",\n      \"fspId\": \"{{payeefsp}}\"\n    }\n  },\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"27713803905\",\n      \"fspId\": \"{{payerfsp}}\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+													"host": [
+														"{{HOST_QUOTING_SERVICE}}"
+													],
+													"path": [
+														"quotes"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Transfer-Prepare",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+														"exec": [
+															"",
+															"var uuid = require('uuid');",
+															"var generatedUUID = uuid.v4();",
+															"pm.environment.set('transfer_ID', generatedUUID);",
+															"pm.environment.set('transferDate', (new Date()).toUTCString());",
+															"pm.environment.set('transferAmount', 100);",
+															"",
+															"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Date",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "{{payerfsp}}"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Signature",
+														"value": "{{fspiop-signature}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Fulfill-Reject",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
+														"exec": [
+															"pm.environment.set(\"completedTimestamp\",new Date().toISOString());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"          if(response.responseSize !== 0) {",
+															"              //Check headers",
+															"              var headers = response.json().headers;",
+															"              ",
+															"                pm.test(\"fspiop-source is noresponsepayeefsp\", function () {",
+															"                    pm.expect(headers['fspiop-source']).to.eql('noresponsepayeefsp');",
+															"                });",
+															"                ",
+															"                pm.test(\"fspiop-destination is payerfsp\", function () {",
+															"                    pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
+															"                });",
+															"                ",
+															"                //Uncomment after JWS is implemented",
+															"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
+															"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
+															"                // });",
+															"                ",
+															"                pm.test(\"date header should not be empty\", function () {",
+															"                    pm.expect(headers['date']).to.be.not.empty;",
+															"                });",
+															"                ",
+															"                pm.test(\"accept header should not be sent in the response\", function () {",
+															"                    pm.expect(headers['accept']).to.eql(undefined);",
+															"                });",
+															"                ",
+															"                pm.test(\"payeefsp content-type is same as sent in the request\", function () {",
+															"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+															"                });",
+															"                ",
+															"              //Check data",
+															"              var jsonData = response.json().data;",
+															"              pm.test(\"Response Error Code is 5101\", function () {",
+															"                pm.expect(jsonData.errorInformation.errorCode).to.eql('5101');",
+															"              });",
+															"              ",
+															"              pm.test(\"Response Error Desription is 'Payee transaction limit reached'\", function () {",
+															"                pm.expect(jsonData.errorInformation.errorDescription).to.eql('Payee transaction limit reached');",
+															"              });",
+															"              ",
+															"          } else {",
+															"              pm.test(\"Transfer FAILED\", function () {",
+															"                throw new Error('Did not receive response');",
+															"              });",
+															"",
+															"          }",
+															"   });",
+															"}, 5000)"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{PAYEEFSP_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/vnd.interoperability.transfers+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"type": "text",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"type": "text",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"type": "text",
+														"value": "{{payerfsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n\t\"errorInformation\": {\n\t\t\"errorCode\": \"5101\",\n\t\t\"errorDescription\": \"Payee transaction limit reached\",\n\t\t\"extensionList\": {\n\t\t\t\"extension\": [{\n\t\t\t\t\"key\": \"errorDetail\",\n\t\t\t\t\"value\": \"This is an abort extension\"\n\t\t\t}]\n\t\t}\n\t}\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}/error",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers",
+														"{{transfer_ID}}",
+														"error"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Duplicate Fulfill-Reject",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"//Not getting any response from simulator, at least no response body I mean. Can enable the below once that is addressed.",
+															"",
+															"// setTimeout(function () {",
+															"//   pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/noresponsepayeefsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"//           if(response.responseSize !== 0) {",
+															"//               //Check headers",
+															"//               var headers = response.json().headers;",
+															"              ",
+															"//                 pm.test(\"fspiop-source is switch\", function () {",
+															"//                     pm.expect(headers['fspiop-source']).to.eql('switch');",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"fspiop-destination is noresponsepayeefsp\", function () {",
+															"//                     pm.expect(headers['fspiop-destination']).to.eql('noresponsepayeefsp');",
+															"//                 });",
+															"                ",
+															"//                 //Uncomment after JWS is implemented",
+															"//                 // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
+															"//                 //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
+															"//                 // });",
+															"                ",
+															"//                 pm.test(\"date header should not be empty\", function () {",
+															"//                     pm.expect(headers['date']).to.be.not.empty;",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"accept header should not be sent in the response\", function () {",
+															"//                     pm.expect(headers['accept']).to.eql(undefined);",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"content-type is same as sent in the request\", function () {",
+															"//                     pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+															"//                 });",
+															"                ",
+															"//               //Check data",
+															"//               var jsonData = response.json().data;",
+															"//               pm.test(\"Response transferState should be ABORTED\", function () {",
+															"//                 pm.expect(jsonData.transferState).to.eql('ABORTED');",
+															"//               });",
+															"              ",
+															"//               pm.test(\"Response fulfilment should be empty\", function () {",
+															"//                 pm.expect(jsonData.fulfilment).to.eql(undefined);",
+															"//               });",
+															"//           } else {",
+															"//               pm.test(\"Transfer FAILED\", function () {",
+															"//                 throw new Error('Did not receive response');",
+															"//               });",
+															"",
+															"//           }",
+															"//   });",
+															"// }, 5000)"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{PAYEEFSP_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/vnd.interoperability.transfers+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"type": "text",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"type": "text",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"type": "text",
+														"value": "{{payerfsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n\t\"errorInformation\": {\n\t\t\"errorCode\": \"5101\",\n\t\t\"errorDescription\": \"Payee transaction limit reached\",\n\t\t\"extensionList\": {\n\t\t\t\"extension\": [{\n\t\t\t\t\"key\": \"errorDetail\",\n\t\t\t\t\"value\": \"This is an abort extension\"\n\t\t\t}]\n\t\t}\n\t}\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}/error",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers",
+														"{{transfer_ID}}",
+														"error"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								},
+								{
+									"name": "negative",
+									"item": [
+										{
+											"name": "Send Quote",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+														"exec": [
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+															"   var uuid = require('uuid');",
+															"   var generatedUUID = uuid.v4();",
+															"   pm.variables.set('quoteId', generatedUUID);",
+															"}",
+															"",
+															"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+															"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+															"}"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "b7ca6bc0-b58a-46d8-8881-2db1aa0703ef",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"// pm.test(\"Check that Content-Type is present\", function () {",
+															"//     pm.response.to.have.header(\"Content-Type\");",
+															"//     pm.response.to.be.header(\"Content-Type\", \"application/vnd.interoperability.quotes+json;version=1.0\");",
+															"// });",
+															"",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/correlationid/\"+pm.variables.get(\"quoteId\"), function (err, response) {",
+															"      if(response.responseSize !== 0) {",
+															"          console.log('response: ',response.json());",
+															"       pm.test(\"Response ilpPacket is not undefined\", function () {",
+															"           console.log('ilpPacket: ',response.json().ilpPacket)",
+															"           pm.expect(response.json().ilpPacket).not.eql(undefined);",
+															"          pm.environment.set(\"ilpPacket\", response.json().ilpPacket);",
+															"           ",
+															"       });",
+															"       ",
+															"       pm.test(\"Response condition is not undefined\", function () {",
+															"           pm.expect(response.json().condition).not.eql(undefined);",
+															"           pm.environment.set(\"condition\", response.json().condition);",
+															"       });",
+															"      } else {",
+															"          pm.test(\"Quote FAILED\", function () {",
+															"            throw new Error('Did not receive response');",
+															"           });",
+															"",
+															"      }",
+															"       ",
+															"   });",
+															"}, 1000)",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.quotes+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.quotes+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"value": "{{quoteDate}}"
+													},
+													{
+														"key": "FSPIOP-SOurce",
+														"value": "{{payerfsp}}"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "{{payeefsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"quoteId\": \"{{quoteId}}\",\n  \"transactionId\": \"{{quoteId}}\",\n  \"payee\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"{{receiverMSISDN}}\",\n      \"fspId\": \"{{payeefsp}}\"\n    }\n  },\n  \"payer\": {\n    \"partyIdInfo\": {\n      \"partyIdType\": \"MSISDN\",\n      \"partyIdentifier\": \"27713803905\",\n      \"fspId\": \"{{payerfsp}}\"\n    },\n    \"personalInfo\": {\n      \"complexName\": {\n        \"firstName\": \"Mats\",\n        \"lastName\": \"Hagman\"\n      },\n      \"dateOfBirth\": \"1983-10-25\"\n    }\n  },\n  \"amountType\": \"SEND\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"transactionType\": {\n    \"scenario\": \"TRANSFER\",\n    \"initiator\": \"PAYER\",\n    \"initiatorType\": \"CONSUMER\"\n  },\n  \"note\": \"hej\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_QUOTING_SERVICE}}/quotes",
+													"host": [
+														"{{HOST_QUOTING_SERVICE}}"
+													],
+													"path": [
+														"quotes"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Transfer-Prepare",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "16b4580d-74c7-44e9-952e-d40a61f9cb69",
+														"exec": [
+															"",
+															"var uuid = require('uuid');",
+															"var generatedUUID = uuid.v4();",
+															"pm.environment.set('transfer_ID', generatedUUID);",
+															"pm.environment.set('transferDate', (new Date()).toUTCString());",
+															"pm.environment.set('transferAmount', 100);",
+															"",
+															"pm.environment.set(\"transferExpiration\",new Date(new Date().getTime() + 120000))"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "e47ebaa4-926e-4007-821a-e68cd385e18c",
+														"exec": [
+															"pm.test(\"Status code is 202\", function () {",
+															"    pm.response.to.have.status(202);",
+															"});",
+															"",
+															"",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.interoperability.transfers+json;version=1"
+													},
+													{
+														"key": "Date",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"value": "{{payerfsp}}"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Signature",
+														"value": "{{fspiop-signature}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"transferId\": \"{{transfer_ID}}\",\n  \"payerFsp\": \"{{payerfsp}}\",\n  \"payeeFsp\": \"noresponsepayeefsp\",\n  \"amount\": {\n    \"amount\": \"100\",\n    \"currency\": \"{{currency}}\"\n  },\n  \"expiration\": \"{{transferExpiration}}\",\n  \"ilpPacket\": \"{{ilpPacket}}\",\n  \"condition\": \"{{validCondition}}\"\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Fulfill-Reject",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
+														"exec": [
+															"pm.environment.set(\"completedTimestamp\",new Date().toISOString());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"setTimeout(function () {",
+															"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"          if(response.responseSize !== 0) {",
+															"              //Check headers",
+															"              var headers = response.json().headers;",
+															"              ",
+															"                pm.test(\"fspiop-source is noresponsepayeefsp\", function () {",
+															"                    pm.expect(headers['fspiop-source']).to.eql('noresponsepayeefsp');",
+															"                });",
+															"                ",
+															"                pm.test(\"fspiop-destination is payerfsp\", function () {",
+															"                    pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
+															"                });",
+															"                ",
+															"                //Uncomment after JWS is implemented",
+															"                // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
+															"                //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
+															"                // });",
+															"                ",
+															"                ",
+															"                pm.test(\"payeefsp content-type is same as sent in the request\", function () {",
+															"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+															"                });",
+															"                ",
+															"                pm.test(\"date header should not be empty\", function () {",
+															"                    pm.expect(headers['date']).to.be.not.empty;",
+															"                });",
+															"                ",
+															"                pm.test(\"accept header should not be sent in the response\", function () {",
+															"                    pm.expect(headers['accept']).to.eql(undefined);",
+															"                });",
+															"                ",
+															"              //Check data",
+															"              var jsonData = response.json().data;",
+															"              pm.test(\"Response Error Code is 5101\", function () {",
+															"                pm.expect(jsonData.errorInformation.errorCode).to.eql('5101');",
+															"              });",
+															"              ",
+															"              pm.test(\"Response Error Desription is 'Payee transaction limit reached'\", function () {",
+															"                pm.expect(jsonData.errorInformation.errorDescription).to.eql('Payee transaction limit reached');",
+															"              });",
+															"              ",
+															"          } else {",
+															"              pm.test(\"Transfer FAILED\", function () {",
+															"                throw new Error('Did not receive response');",
+															"              });",
+															"              ",
+															"          }",
+															"   });",
+															"}, 5000)"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{PAYEEFSP_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/vnd.interoperability.transfers+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"type": "text",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"type": "text",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"type": "text",
+														"value": "{{payerfsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n\t\"errorInformation\": {\n\t\t\"errorCode\": \"5101\",\n\t\t\"errorDescription\": \"Payee transaction limit reached\",\n\t\t\"extensionList\": {\n\t\t\t\"extension\": [{\n\t\t\t\t\"key\": \"errorDetail\",\n\t\t\t\t\"value\": \"This is an abort extension\"\n\t\t\t}]\n\t\t}\n\t}\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}/error",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers",
+														"{{transfer_ID}}",
+														"error"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Send Invalid Duplicate Fulfill-Reject",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "2e244cfd-ff69-448a-8b62-176d4dd0b28d",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"id": "358f8ed8-6882-4c54-8dfd-177607c9e07b",
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"// setTimeout(function () {",
+															"//   pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/noresponsepayeefsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+															"//           if(response.responseSize !== 0) {",
+															"//               //Check headers",
+															"//               var headers = response.json().headers;",
+															"              ",
+															"//                 pm.test(\"fspiop-source is switch\", function () {",
+															"//                     pm.expect(headers['fspiop-source']).to.eql('switch');",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"fspiop-destination is noresponsepayeefsp\", function () {",
+															"//                     pm.expect(headers['fspiop-destination']).to.eql('noresponsepayeefsp');",
+															"//                 });",
+															"                ",
+															"//                 //Uncomment after JWS is implemented",
+															"//                 // pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
+															"//                 //     pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
+															"//                 // });",
+															"//                 pm.test(\"date header should not be empty\", function () {",
+															"//                     pm.expect(headers['date']).to.be.not.empty;",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"accept header should not be sent in the response\", function () {",
+															"//                     pm.expect(headers['accept']).to.eql(undefined);",
+															"//                 });",
+															"                ",
+															"//                 pm.test(\"content-type is same as sent in the request\", function () {",
+															"//                     pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+															"//                 });",
+															"                ",
+															"//               //Check data",
+															"//               var jsonData = response.json().data;",
+															"//               pm.test(\"Response Error Code is '3106'\", function () {",
+															"//                 pm.expect(jsonData.errorInformation.errorCode).to.eql('3106');",
+															"//               });",
+															"              ",
+															"//               pm.test(\"Response Error Desription is 'Modified request'\", function () {",
+															"//                 pm.expect(jsonData.errorInformation.errorDescription).to.eql('Modified request');",
+															"//               });",
+															"              ",
+															"//           } else {",
+															"//               pm.test(\"Transfer FAILED\", function () {",
+															"//                 throw new Error('Did not receive response');",
+															"//               });",
+															"",
+															"//           }",
+															"//   });",
+															"// }, 5000)"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"auth": {
+													"type": "bearer",
+													"bearer": [
+														{
+															"key": "token",
+															"value": "{{PAYEEFSP_BEARER_TOKEN}}",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/vnd.interoperability.transfers+json;version=1.0"
+													},
+													{
+														"key": "Date",
+														"type": "text",
+														"value": "{{dateHeader}}"
+													},
+													{
+														"key": "FSPIOP-Source",
+														"type": "text",
+														"value": "noresponsepayeefsp"
+													},
+													{
+														"key": "FSPIOP-Destination",
+														"type": "text",
+														"value": "{{payerfsp}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n\t\"errorInformation\": {\n\t\t\"errorCode\": \"5101\",\n\t\t\"errorDescription\": \"This is an invalid duplicate request\",\n\t\t\"extensionList\": {\n\t\t\t\"extension\": [{\n\t\t\t\t\"key\": \"errorDetail\",\n\t\t\t\t\"value\": \"This is an abort extension\"\n\t\t\t}]\n\t\t}\n\t}\n}"
+												},
+												"url": {
+													"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/{{transfer_ID}}/error",
+													"host": [
+														"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
+													],
+													"path": [
+														"transfers",
+														"{{transfer_ID}}",
+														"error"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								}
+							],
+							"description": "Send a transfer-prepare from payerfsp to payeefsp\nDo not send transfer-fulfil from payeefsp.\n\nSend a duplicate transfer-prepare with same params.\ncheck the simulator logs to make sure that there should not be any response for the duplicate transfer when the actual transfer is not at terminal state which means neither committed nor aborted but in process.\n\nThis is same as sending duplicate transfer when actual transfer is at ABORTED state.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb820baa-0cb0-4c41-9955-8f96395d68a6",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "61fcc61f-21fc-4b4f-b320-c64702d73893",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				}
+			]
 		},
 		{
 			"name": "participant_inactive_stop_tranfers",
-			"item": [{
-				"name": "Update Participant to inactive",
-				"event": [{
-					"listen": "test",
-					"script": {
-						"id": "f41cd084-912e-4fe0-af17-e8ee86fa7b4d",
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}],
-				"request": {
-					"auth": {
-						"type": "bearer",
-						"bearer": [{
-							"key": "token",
-							"value": "{{BEARER_TOKEN}}",
-							"type": "string"
-						}]
-					},
-					"method": "PUT",
-					"header": [{
-						"key": "Content-Type",
-						"value": "application/json"
-					}],
-					"body": {
-						"mode": "raw",
-						"raw": "{\n  \"isActive\": false\n}"
-					},
-					"url": {
-						"raw": "{{HOST_CENTRAL_LEDGER}}/participants/{{payerfsp}}",
-						"host": [
-							"{{HOST_CENTRAL_LEDGER}}"
-						],
-						"path": [
-							"participants",
-							"{{payerfsp}}"
-						]
-					}
-				},
-				"response": []
-			},
+			"item": [
 				{
-					"name": "Send Quote",
-					"event": [{
-						"listen": "prerequest",
-						"script": {
-							"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-							"exec": [
-								"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-								"   var uuid = require('uuid');",
-								"   var generatedUUID = uuid.v4();",
-								"   pm.variables.set('quoteId', generatedUUID);",
-								"}",
-								"",
-								"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-								"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-								"}"
+					"name": "Update Participant to inactive",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f41cd084-912e-4fe0-af17-e8ee86fa7b4d",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BEARER_TOKEN}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"isActive\": false\n}"
+						},
+						"url": {
+							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/{{payerfsp}}",
+							"host": [
+								"{{HOST_CENTRAL_LEDGER}}"
 							],
-							"type": "text/javascript"
+							"path": [
+								"participants",
+								"{{payerfsp}}"
+							]
 						}
 					},
+					"response": []
+				},
+				{
+					"name": "Send Quote",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+								"exec": [
+									"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+									"   var uuid = require('uuid');",
+									"   var generatedUUID = uuid.v4();",
+									"   pm.variables.set('quoteId', generatedUUID);",
+									"}",
+									"",
+									"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+									"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
 						{
 							"listen": "test",
 							"script": {
@@ -10449,10 +10637,11 @@
 					],
 					"request": {
 						"method": "POST",
-						"header": [{
-							"key": "Accept",
-							"value": "application/vnd.interoperability.quotes+json;version=1"
-						},
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.interoperability.quotes+json;version=1"
+							},
 							{
 								"key": "Content-Type",
 								"value": "application/vnd.interoperability.quotes+json;version=1.0"
@@ -10488,73 +10677,74 @@
 				},
 				{
 					"name": "Send Transfer fail",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "900142b0-e4d7-43a4-a751-38202b600661",
-							"exec": [
-								"pm.test(\"Status code is 202\", function () {",
-								"    pm.response.to.have.status(202);",
-								"});",
-								"",
-								"//Check the callback response that Switch forwards to payerfsp",
-								"setTimeout(function () {",
-								"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-								"          if(response.responseSize !== 0) {",
-								"            //Checking headers",
-								"            var headers = response.json().headers;",
-								"            pm.test(\"payerfsp fspiop-source is switch\", function () {",
-								"                pm.expect(headers['fspiop-source']).to.eql('switch');",
-								"            });",
-								"            ",
-								"            pm.test(\"payerfsp fspiop-destination is payerfsp\", function () {",
-								"                pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
-								"            });",
-								"            ",
-								"            //Uncomment this once Simulators are able to forward Signature",
-								"            // pm.test(\"fspiop-signature is empty\", function () {",
-								"            //     pm.expect(pm.response.json().headers['fspiop-signature']).to.eql(undefined);",
-								"            // });",
-								"            ",
-								"            pm.test(\"payerfsp accept is empty\", function () {",
-								"                pm.expect(headers['accept']).to.eql(undefined);",
-								"            });",
-								"            ",
-								"            pm.test(\"payerfsp content-type should be application/vnd.interoperability.transfers+json;version=1.0\", function () {",
-								"                pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-								"            });",
-								"            ",
-								"            //pm.test(\"payerfsp fspiop-uri is /transfers/\"+pm.environment.get(\"transfer_ID\"), function () {",
-								"            //    pm.expect(headers['fspiop-uri']).to.eql('/transfers/'+pm.environment.get(\"transfer_ID\"));",
-								"            //});",
-								"            ",
-								"            // pm.test(\"payerfsp fspiop-http-method is empty\", function () {",
-								"            //     pm.expect(headers['fspiop-http-method']).to.eql(undefined);",
-								"            // });",
-								"            ",
-								"            var jsonData = response.json().data;",
-								"            pm.test(\"Error Code should be 3100\", function () {",
-								"                pm.expect(jsonData.errorInformation.errorCode).to.eql('3100');",
-								"              });",
-								"              pm.test(\"Error Description should be: Generic validation error: Participant payerfsp is inactive\", function () {",
-								"                pm.expect(jsonData.errorInformation.errorDescription).to.eql('Generic validation error: Participant payerfsp is inactive');",
-								"              });",
-								"              ",
-								"          } else {",
-								"              pm.test(\"Transfer FAILED\", function () {",
-								"                throw new Error('Did not receive response');",
-								"              });",
-								"",
-								"          }",
-								"   });",
-								"}, 1100)",
-								"",
-								"",
-								""
-							],
-							"type": "text/javascript"
-						}
-					},
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "900142b0-e4d7-43a4-a751-38202b600661",
+								"exec": [
+									"pm.test(\"Status code is 202\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									"",
+									"//Check the callback response that Switch forwards to payerfsp",
+									"setTimeout(function () {",
+									"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+									"          if(response.responseSize !== 0) {",
+									"            //Checking headers",
+									"            var headers = response.json().headers;",
+									"            pm.test(\"payerfsp fspiop-source is switch\", function () {",
+									"                pm.expect(headers['fspiop-source']).to.eql('switch');",
+									"            });",
+									"            ",
+									"            pm.test(\"payerfsp fspiop-destination is payerfsp\", function () {",
+									"                pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
+									"            });",
+									"            ",
+									"            //Uncomment this once Simulators are able to forward Signature",
+									"            // pm.test(\"fspiop-signature is empty\", function () {",
+									"            //     pm.expect(pm.response.json().headers['fspiop-signature']).to.eql(undefined);",
+									"            // });",
+									"            ",
+									"            pm.test(\"payerfsp accept is empty\", function () {",
+									"                pm.expect(headers['accept']).to.eql(undefined);",
+									"            });",
+									"            ",
+									"            pm.test(\"payerfsp content-type should be application/vnd.interoperability.transfers+json;version=1.0\", function () {",
+									"                pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+									"            });",
+									"            ",
+									"            //pm.test(\"payerfsp fspiop-uri is /transfers/\"+pm.environment.get(\"transfer_ID\"), function () {",
+									"            //    pm.expect(headers['fspiop-uri']).to.eql('/transfers/'+pm.environment.get(\"transfer_ID\"));",
+									"            //});",
+									"            ",
+									"            // pm.test(\"payerfsp fspiop-http-method is empty\", function () {",
+									"            //     pm.expect(headers['fspiop-http-method']).to.eql(undefined);",
+									"            // });",
+									"            ",
+									"            var jsonData = response.json().data;",
+									"            pm.test(\"Error Code should be 3100\", function () {",
+									"                pm.expect(jsonData.errorInformation.errorCode).to.eql('3100');",
+									"              });",
+									"              pm.test(\"Error Description should be: Generic validation error: Participant payerfsp is inactive\", function () {",
+									"                pm.expect(jsonData.errorInformation.errorDescription).to.eql('Generic validation error: Participant payerfsp is inactive');",
+									"              });",
+									"              ",
+									"          } else {",
+									"              pm.test(\"Transfer FAILED\", function () {",
+									"                throw new Error('Did not receive response');",
+									"              });",
+									"",
+									"          }",
+									"   });",
+									"}, 1100)",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
 						{
 							"listen": "prerequest",
 							"script": {
@@ -10574,10 +10764,11 @@
 					],
 					"request": {
 						"method": "POST",
-						"header": [{
-							"key": "Accept",
-							"value": "application/vnd.interoperability.transfers+json;version=1"
-						},
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.interoperability.transfers+json;version=1"
+							},
 							{
 								"key": "Content-Type",
 								"value": "application/vnd.interoperability.transfers+json;version=1.0"
@@ -10628,32 +10819,38 @@
 				},
 				{
 					"name": "Update Participant to active",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "f41cd084-912e-4fe0-af17-e8ee86fa7b4d",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});"
-							],
-							"type": "text/javascript"
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f41cd084-912e-4fe0-af17-e8ee86fa7b4d",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
 						}
-					}],
+					],
 					"request": {
 						"auth": {
 							"type": "bearer",
-							"bearer": [{
-								"key": "token",
-								"value": "{{BEARER_TOKEN}}",
-								"type": "string"
-							}]
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BEARER_TOKEN}}",
+									"type": "string"
+								}
+							]
 						},
 						"method": "PUT",
-						"header": [{
-							"key": "Content-Type",
-							"value": "application/json"
-						}],
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n  \"isActive\": true\n}"
@@ -10673,24 +10870,25 @@
 				},
 				{
 					"name": "Send Quote",
-					"event": [{
-						"listen": "prerequest",
-						"script": {
-							"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
-							"exec": [
-								"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
-								"   var uuid = require('uuid');",
-								"   var generatedUUID = uuid.v4();",
-								"   pm.variables.set('quoteId', generatedUUID);",
-								"}",
-								"",
-								"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
-								"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
-								"}"
-							],
-							"type": "text/javascript"
-						}
-					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "887e4721-3923-41bd-bf8a-3d0cd5eed8ee",
+								"exec": [
+									"if (pm.environment.get('CONFIG_GENERATE_NEW_TRANSFER_UUID_ON_PREPARE') === 'true') {",
+									"   var uuid = require('uuid');",
+									"   var generatedUUID = uuid.v4();",
+									"   pm.variables.set('quoteId', generatedUUID);",
+									"}",
+									"",
+									"if (pm.environment.get('CONFIG_GENERATE_NEW_PREPARE_DATE') === 'true') {",
+									"   pm.variables.set('quoteDate', (new Date()).toUTCString());",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
 						{
 							"listen": "test",
 							"script": {
@@ -10740,10 +10938,11 @@
 					],
 					"request": {
 						"method": "POST",
-						"header": [{
-							"key": "Accept",
-							"value": "application/vnd.interoperability.quotes+json;version=1"
-						},
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.interoperability.quotes+json;version=1"
+							},
 							{
 								"key": "Content-Type",
 								"value": "application/vnd.interoperability.quotes+json;version=1.0"
@@ -10779,145 +10978,146 @@
 				},
 				{
 					"name": "Send Transfer pass",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "900142b0-e4d7-43a4-a751-38202b600661",
-							"exec": [
-								"pm.test(\"Status code is 202\", function () {",
-								"    pm.response.to.have.status(202);",
-								"});",
-								"",
-								"//Check the request that Switch forwards to payeefsp",
-								"setTimeout(function () {",
-								"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payeefsp/requests/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-								"          if(response.responseSize !== 0) {",
-								"              ",
-								"              //Check the Headers",
-								"              var headers = response.json().headers;",
-								"              ",
-								"                pm.test(\"payeefsp fspiop-source is payerfsp\", function () {",
-								"                    pm.expect(headers['fspiop-source']).to.eql('payerfsp');",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp fspiop-destination is payeefsp\", function () {",
-								"                    pm.expect(headers['fspiop-destination']).to.eql('payeefsp');",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp content-typeis same as sent in the request\", function () {",
-								"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp accept is same as sent in the request\", function () {",
-								"                    pm.expect(headers['accept']).to.eql('application/vnd.interoperability.transfers+json;version=1');",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
-								"                    pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp fspiop-http-method is POST\", function () {",
-								"                    pm.expect(headers['fspiop-http-method']).to.eql('POST');",
-								"                });",
-								"                ",
-								"                pm.test(\"payeefsp fspiop-uri is /transfers\", function () {",
-								"                    pm.expect(headers['fspiop-uri']).to.eql('/transfers');",
-								"                });",
-								"                ",
-								"                ",
-								"                //Check the data",
-								"                var jsonData = response.json().data;",
-								"                pm.test(\"payeefsp data should have the same transferId as request\", function () {",
-								"                   pm.expect(jsonData.transferId).to.eql(pm.environment.get(\"transfer_ID\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same payerfspId as request\", function () {",
-								"                   pm.expect(jsonData.payerFsp).to.eql(pm.environment.get(\"payerfsp\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same payeefspId as request\", function () {",
-								"                   pm.expect(jsonData.payeeFsp).to.eql(pm.environment.get(\"payeefsp\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same amount as request\", function () {",
-								"                   pm.expect(jsonData.amount.amount).to.eql('1');",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same currency as request\", function () {",
-								"                   pm.expect(jsonData.amount.currency).to.eql(pm.environment.get(\"currency\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same expiration as request\", function () {",
-								"                   pm.expect(jsonData.expiration).to.eql(pm.environment.get(\"transferExpiration\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same ilpPacket as request\", function () {",
-								"                   pm.expect(jsonData.ilpPacket).to.eql(pm.environment.get(\"ilpPacket\"));",
-								"                });",
-								"                pm.test(\"payeefsp data should have the same condition as request\", function () {",
-								"                   pm.expect(jsonData.condition).to.eql(pm.environment.get(\"condition\"));",
-								"                });",
-								"                ",
-								"          } else {",
-								"              pm.test(\"Transfer FAILED\", function () {",
-								"                throw new Error('Did not receive response');",
-								"              });",
-								"              ",
-								"          }",
-								"   });",
-								"}, 1100)",
-								"",
-								"//Check the callback response that Switch forwards to payerfsp",
-								"setTimeout(function () {",
-								"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
-								"          if(response.responseSize !== 0) {",
-								"            //Checking headers",
-								"            var headers = response.json().headers;",
-								"            pm.test(\"payerfsp fspiop-source is payeefsp\", function () {",
-								"                pm.expect(headers['fspiop-source']).to.eql('payeefsp');",
-								"            });",
-								"            ",
-								"            pm.test(\"payerfsp fspiop-destination is payerfsp\", function () {",
-								"                pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
-								"            });",
-								"            ",
-								"            pm.test(\"payerfsp content-type should be application/vnd.interoperability.transfers+json;version=1.0\", function () {",
-								"                pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
-								"            });",
-								"            ",
-								"            pm.test(\"payerfsp accept is empty\", function () {",
-								"                pm.expect(headers['accept']).to.eql(undefined);",
-								"            });",
-								"            ",
-								"            //pm.test(\"fspiop-signature is returned\", function () {",
-								"            //    pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"payeefsp_fspiop_signature\"));",
-								"            //});",
-								"           ",
-								"            ",
-								"            pm.test(\"payerfsp fspiop-uri includes transfers\", function () {",
-								"                pm.expect(headers['fspiop-uri']).to.include('/transfers');",
-								"            });",
-								"            ",
-								"            pm.test(\"payerfsp fspiop-http-method is PUT\", function () {",
-								"                pm.expect(headers['fspiop-http-method']).to.eql('PUT');",
-								"            });",
-								"            ",
-								"            var jsonData = response.json().data;",
-								"            pm.test(\"Response data does not have transferId\", function () {",
-								"               pm.expect(jsonData.transferId).to.eql(undefined);",
-								"            });",
-								"            pm.test(\"Response status is COMMITTED\", function () {",
-								"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
-								"            });",
-								"          } else {",
-								"              pm.test(\"Transfer FAILED\", function () {",
-								"                throw new Error('Did not receive response');",
-								"              });",
-								"              ",
-								"          }",
-								"   });",
-								"}, 1300)",
-								"",
-								"",
-								""
-							],
-							"type": "text/javascript"
-						}
-					},
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "900142b0-e4d7-43a4-a751-38202b600661",
+								"exec": [
+									"pm.test(\"Status code is 202\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									"",
+									"//Check the request that Switch forwards to payeefsp",
+									"setTimeout(function () {",
+									"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payeefsp/requests/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+									"          if(response.responseSize !== 0) {",
+									"              ",
+									"              //Check the Headers",
+									"              var headers = response.json().headers;",
+									"              ",
+									"                pm.test(\"payeefsp fspiop-source is payerfsp\", function () {",
+									"                    pm.expect(headers['fspiop-source']).to.eql('payerfsp');",
+									"                });",
+									"                ",
+									"                pm.test(\"payeefsp fspiop-destination is payeefsp\", function () {",
+									"                    pm.expect(headers['fspiop-destination']).to.eql('payeefsp');",
+									"                });",
+									"                ",
+									"                pm.test(\"payeefsp content-typeis same as sent in the request\", function () {",
+									"                    pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+									"                });",
+									"                ",
+									"                pm.test(\"payeefsp accept is same as sent in the request\", function () {",
+									"                    pm.expect(headers['accept']).to.eql('application/vnd.interoperability.transfers+json;version=1');",
+									"                });",
+									"                ",
+									"                pm.test(\"payeefsp fspiop-signature is same as sent in the request\", function () {",
+									"                    pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"fspiop-signature\"));",
+									"                });",
+									"                ",
+									"                pm.test(\"payeefsp fspiop-http-method is POST\", function () {",
+									"                    pm.expect(headers['fspiop-http-method']).to.eql('POST');",
+									"                });",
+									"                ",
+									"                pm.test(\"payeefsp fspiop-uri is /transfers\", function () {",
+									"                    pm.expect(headers['fspiop-uri']).to.eql('/transfers');",
+									"                });",
+									"                ",
+									"                ",
+									"                //Check the data",
+									"                var jsonData = response.json().data;",
+									"                pm.test(\"payeefsp data should have the same transferId as request\", function () {",
+									"                   pm.expect(jsonData.transferId).to.eql(pm.environment.get(\"transfer_ID\"));",
+									"                });",
+									"                pm.test(\"payeefsp data should have the same payerfspId as request\", function () {",
+									"                   pm.expect(jsonData.payerFsp).to.eql(pm.environment.get(\"payerfsp\"));",
+									"                });",
+									"                pm.test(\"payeefsp data should have the same payeefspId as request\", function () {",
+									"                   pm.expect(jsonData.payeeFsp).to.eql(pm.environment.get(\"payeefsp\"));",
+									"                });",
+									"                pm.test(\"payeefsp data should have the same amount as request\", function () {",
+									"                   pm.expect(jsonData.amount.amount).to.eql('1');",
+									"                });",
+									"                pm.test(\"payeefsp data should have the same currency as request\", function () {",
+									"                   pm.expect(jsonData.amount.currency).to.eql(pm.environment.get(\"currency\"));",
+									"                });",
+									"                pm.test(\"payeefsp data should have the same expiration as request\", function () {",
+									"                   pm.expect(jsonData.expiration).to.eql(pm.environment.get(\"transferExpiration\"));",
+									"                });",
+									"                pm.test(\"payeefsp data should have the same ilpPacket as request\", function () {",
+									"                   pm.expect(jsonData.ilpPacket).to.eql(pm.environment.get(\"ilpPacket\"));",
+									"                });",
+									"                pm.test(\"payeefsp data should have the same condition as request\", function () {",
+									"                   pm.expect(jsonData.condition).to.eql(pm.environment.get(\"condition\"));",
+									"                });",
+									"                ",
+									"          } else {",
+									"              pm.test(\"Transfer FAILED\", function () {",
+									"                throw new Error('Did not receive response');",
+									"              });",
+									"              ",
+									"          }",
+									"   });",
+									"}, 1100)",
+									"",
+									"//Check the callback response that Switch forwards to payerfsp",
+									"setTimeout(function () {",
+									"  pm.sendRequest(pm.environment.get(\"HOST_SIMULATOR\")+\"/payerfsp/callbacks/\"+pm.environment.get(\"transfer_ID\"), function (err, response) {",
+									"          if(response.responseSize !== 0) {",
+									"            //Checking headers",
+									"            var headers = response.json().headers;",
+									"            pm.test(\"payerfsp fspiop-source is payeefsp\", function () {",
+									"                pm.expect(headers['fspiop-source']).to.eql('payeefsp');",
+									"            });",
+									"            ",
+									"            pm.test(\"payerfsp fspiop-destination is payerfsp\", function () {",
+									"                pm.expect(headers['fspiop-destination']).to.eql('payerfsp');",
+									"            });",
+									"            ",
+									"            pm.test(\"payerfsp content-type should be application/vnd.interoperability.transfers+json;version=1.0\", function () {",
+									"                pm.expect(headers['content-type']).to.eql('application/vnd.interoperability.transfers+json;version=1.0');",
+									"            });",
+									"            ",
+									"            pm.test(\"payerfsp accept is empty\", function () {",
+									"                pm.expect(headers['accept']).to.eql(undefined);",
+									"            });",
+									"            ",
+									"            //pm.test(\"fspiop-signature is returned\", function () {",
+									"            //    pm.expect(headers['fspiop-signature']).to.eql(pm.environment.get(\"payeefsp_fspiop_signature\"));",
+									"            //});",
+									"           ",
+									"            ",
+									"            pm.test(\"payerfsp fspiop-uri includes transfers\", function () {",
+									"                pm.expect(headers['fspiop-uri']).to.include('/transfers');",
+									"            });",
+									"            ",
+									"            pm.test(\"payerfsp fspiop-http-method is PUT\", function () {",
+									"                pm.expect(headers['fspiop-http-method']).to.eql('PUT');",
+									"            });",
+									"            ",
+									"            var jsonData = response.json().data;",
+									"            pm.test(\"Response data does not have transferId\", function () {",
+									"               pm.expect(jsonData.transferId).to.eql(undefined);",
+									"            });",
+									"            pm.test(\"Response status is COMMITTED\", function () {",
+									"                pm.expect(jsonData.transferState).to.eql('COMMITTED');",
+									"            });",
+									"          } else {",
+									"              pm.test(\"Transfer FAILED\", function () {",
+									"                throw new Error('Did not receive response');",
+									"              });",
+									"              ",
+									"          }",
+									"   });",
+									"}, 1300)",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
 						{
 							"listen": "prerequest",
 							"script": {
@@ -10937,10 +11137,11 @@
 					],
 					"request": {
 						"method": "POST",
-						"header": [{
-							"key": "Accept",
-							"value": "application/vnd.interoperability.transfers+json;version=1"
-						},
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.interoperability.transfers+json;version=1"
+							},
 							{
 								"key": "Content-Type",
 								"value": "application/vnd.interoperability.transfers+json;version=1.0"
@@ -10993,76 +11194,77 @@
 		},
 		{
 			"name": "api_tests",
-			"item": [{
-				"name": "Get participants List",
-				"event": [{
-					"listen": "test",
-					"script": {
-						"id": "3a6e9554-78e6-4ae8-a533-2cb793f20be8",
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}],
-				"request": {
-					"auth": {
-						"type": "bearer",
-						"bearer": [{
-							"key": "token",
-							"value": "{{BEARER_TOKEN}}",
-							"type": "string"
-						}]
-					},
-					"method": "GET",
-					"header": [],
-					"body": {
-						"mode": "raw",
-						"raw": ""
-					},
-					"url": {
-						"raw": "{{HOST_CENTRAL_LEDGER}}/participants",
-						"host": [
-							"{{HOST_CENTRAL_LEDGER}}"
-						],
-						"path": [
-							"participants"
-						]
-					}
-				},
-				"response": []
-			},
+			"item": [
 				{
-					"name": "3. Get Participant",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "256b48ed-6b90-4656-affb-7221b9b5c55d",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});"
-							],
-							"type": "text/javascript"
+					"name": "Get participants List",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "3a6e9554-78e6-4ae8-a533-2cb793f20be8",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
 						}
-					}],
+					],
 					"request": {
 						"auth": {
 							"type": "bearer",
-							"bearer": [{
-								"key": "token",
-								"value": "{{BEARER_TOKEN}}",
-								"type": "string"
-							}]
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BEARER_TOKEN}}",
+									"type": "string"
+								}
+							]
 						},
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
+						"url": {
+							"raw": "{{HOST_CENTRAL_LEDGER}}/participants",
+							"host": [
+								"{{HOST_CENTRAL_LEDGER}}"
+							],
+							"path": [
+								"participants"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "3. Get Participant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "256b48ed-6b90-4656-affb-7221b9b5c55d",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BEARER_TOKEN}}",
+									"type": "string"
+								}
+							]
 						},
+						"method": "GET",
+						"header": [],
 						"url": {
 							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/{{payerfsp}}",
 							"host": [
@@ -11074,106 +11276,105 @@
 							]
 						}
 					},
-					"response": [{
-						"name": "Get Participant",
-						"originalRequest": {
-							"method": "GET",
-							"header": [],
-							"body": {
-								"mode": "raw",
-								"raw": ""
+					"response": [
+						{
+							"name": "Get Participant",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{participant}}",
+									"protocol": "http",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{participant}}"
+									]
+								}
 							},
-							"url": {
-								"raw": "http://{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{participant}}",
-								"protocol": "http",
-								"host": [
-									"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-								],
-								"path": [
-									"participants",
-									"{{participant}}"
-								]
-							}
-						},
-						"status": "OK",
-						"code": 200,
-						"_postman_previewlanguage": "json",
-						"header": [{
-							"key": "Connection",
-							"value": "keep-alive",
-							"name": "Connection",
-							"description": "Options that are desired for the connection"
-						},
-							{
-								"key": "Content-Length",
-								"value": "251",
-								"name": "Content-Length",
-								"description": "The length of the response body in octets (8-bit bytes)"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json; charset=utf-8",
-								"name": "Content-Type",
-								"description": "The mime type of this content"
-							},
-							{
-								"key": "Date",
-								"value": "Wed, 22 Aug 2018 15:25:18 GMT",
-								"name": "Date",
-								"description": "The date and time that the message was sent"
-							},
-							{
-								"key": "Server",
-								"value": "nginx/1.13.8",
-								"name": "Server",
-								"description": "A name for the server"
-							},
-							{
-								"key": "accept-ranges",
-								"value": "bytes",
-								"name": "accept-ranges",
-								"description": "Content-Types that are acceptable"
-							},
-							{
-								"key": "cache-control",
-								"value": "no-cache",
-								"name": "cache-control",
-								"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
-							}
-						],
-						"cookie": [],
-						"body": "{\"name\":\"testfsp\",\"id\":\"test-central-ledger.mojaloop.test/participants/testfsp\",\"created\":\"2018-08-22T08:16:50.000Z\",\"isActive\":1,\"links\":{\"self\":\"test-central-ledger.mojaloop.test/participants/testfsp\"},\"currencies\":[{\"currency\":\"USD\",\"isActive\":1}]}"
-					}]
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Connection",
+									"value": "keep-alive",
+									"name": "Connection",
+									"description": "Options that are desired for the connection"
+								},
+								{
+									"key": "Content-Length",
+									"value": "251",
+									"name": "Content-Length",
+									"description": "The length of the response body in octets (8-bit bytes)"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=utf-8",
+									"name": "Content-Type",
+									"description": "The mime type of this content"
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 22 Aug 2018 15:25:18 GMT",
+									"name": "Date",
+									"description": "The date and time that the message was sent"
+								},
+								{
+									"key": "Server",
+									"value": "nginx/1.13.8",
+									"name": "Server",
+									"description": "A name for the server"
+								},
+								{
+									"key": "accept-ranges",
+									"value": "bytes",
+									"name": "accept-ranges",
+									"description": "Content-Types that are acceptable"
+								},
+								{
+									"key": "cache-control",
+									"value": "no-cache",
+									"name": "cache-control",
+									"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+								}
+							],
+							"cookie": [],
+							"body": "{\"name\":\"testfsp\",\"id\":\"{{HOST_CENTRAL_LEDGER}}/participants/testfsp\",\"created\":\"2018-08-22T08:16:50.000Z\",\"isActive\":1,\"links\":{\"self\":\"{{HOST_CENTRAL_LEDGER}}/participants/testfsp\"},\"currencies\":[{\"currency\":\"USD\",\"isActive\":1}]}"
+						}
+					]
 				},
 				{
 					"name": "3. Get Hub Account",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "620c61ae-7b06-4d59-82fe-35ffd5a81469",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});"
-							],
-							"type": "text/javascript"
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "620c61ae-7b06-4d59-82fe-35ffd5a81469",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
 						}
-					}],
+					],
 					"request": {
 						"auth": {
 							"type": "bearer",
-							"bearer": [{
-								"key": "token",
-								"value": "{{BEARER_TOKEN}}",
-								"type": "string"
-							}]
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BEARER_TOKEN}}",
+									"type": "string"
+								}
+							]
 						},
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/Hub/accounts",
 							"host": [
@@ -11186,114 +11387,114 @@
 							]
 						}
 					},
-					"response": [{
-						"name": "Get Participant",
-						"originalRequest": {
-							"method": "GET",
-							"header": [],
-							"body": {
-								"mode": "raw",
-								"raw": ""
+					"response": [
+						{
+							"name": "Get Participant",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{participant}}",
+									"protocol": "http",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
+									],
+									"path": [
+										"participants",
+										"{{participant}}"
+									]
+								}
 							},
-							"url": {
-								"raw": "http://{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}/participants/{{participant}}",
-								"protocol": "http",
-								"host": [
-									"{{HOST_CENTRAL_LEDGER}}{{BASE_CENTRAL_LEDGER_ADMIN}}"
-								],
-								"path": [
-									"participants",
-									"{{participant}}"
-								]
-							}
-						},
-						"status": "OK",
-						"code": 200,
-						"_postman_previewlanguage": "json",
-						"header": [{
-							"key": "Connection",
-							"value": "keep-alive",
-							"name": "Connection",
-							"description": "Options that are desired for the connection"
-						},
-							{
-								"key": "Content-Length",
-								"value": "251",
-								"name": "Content-Length",
-								"description": "The length of the response body in octets (8-bit bytes)"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json; charset=utf-8",
-								"name": "Content-Type",
-								"description": "The mime type of this content"
-							},
-							{
-								"key": "Date",
-								"value": "Wed, 22 Aug 2018 15:25:18 GMT",
-								"name": "Date",
-								"description": "The date and time that the message was sent"
-							},
-							{
-								"key": "Server",
-								"value": "nginx/1.13.8",
-								"name": "Server",
-								"description": "A name for the server"
-							},
-							{
-								"key": "accept-ranges",
-								"value": "bytes",
-								"name": "accept-ranges",
-								"description": "Content-Types that are acceptable"
-							},
-							{
-								"key": "cache-control",
-								"value": "no-cache",
-								"name": "cache-control",
-								"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
-							}
-						],
-						"cookie": [],
-						"body": "{\"name\":\"testfsp\",\"id\":\"test-central-ledger.mojaloop.test/participants/testfsp\",\"created\":\"2018-08-22T08:16:50.000Z\",\"isActive\":1,\"links\":{\"self\":\"test-central-ledger.mojaloop.test/participants/testfsp\"},\"currencies\":[{\"currency\":\"USD\",\"isActive\":1}]}"
-					}]
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Connection",
+									"value": "keep-alive",
+									"name": "Connection",
+									"description": "Options that are desired for the connection"
+								},
+								{
+									"key": "Content-Length",
+									"value": "251",
+									"name": "Content-Length",
+									"description": "The length of the response body in octets (8-bit bytes)"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=utf-8",
+									"name": "Content-Type",
+									"description": "The mime type of this content"
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 22 Aug 2018 15:25:18 GMT",
+									"name": "Date",
+									"description": "The date and time that the message was sent"
+								},
+								{
+									"key": "Server",
+									"value": "nginx/1.13.8",
+									"name": "Server",
+									"description": "A name for the server"
+								},
+								{
+									"key": "accept-ranges",
+									"value": "bytes",
+									"name": "accept-ranges",
+									"description": "Content-Types that are acceptable"
+								},
+								{
+									"key": "cache-control",
+									"value": "no-cache",
+									"name": "cache-control",
+									"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+								}
+							],
+							"cookie": [],
+							"body": "{\"name\":\"testfsp\",\"id\":\"{{HOST_CENTRAL_LEDGER}}/participants/testfsp\",\"created\":\"2018-08-22T08:16:50.000Z\",\"isActive\":1,\"links\":{\"self\":\"{{HOST_CENTRAL_LEDGER}}/participants/testfsp\"},\"currencies\":[{\"currency\":\"USD\",\"isActive\":1}]}"
+						}
+					]
 				},
 				{
 					"name": "11. Get Endpoints",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "88ed368c-227c-41c8-bfe8-489449eba6bb",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});"
-							],
-							"type": "text/javascript"
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "88ed368c-227c-41c8-bfe8-489449eba6bb",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
 						}
-					}],
+					],
 					"request": {
 						"auth": {
 							"type": "bearer",
-							"bearer": [{
-								"key": "token",
-								"value": "{{BEARER_TOKEN}}",
-								"type": "string"
-							}]
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BEARER_TOKEN}}",
+									"type": "string"
+								}
+							]
 						},
 						"method": "GET",
-						"header": [{
-							"key": "Cache-Control",
-							"value": "no-cache"
-						},
+						"header": [
+							{
+								"key": "Cache-Control",
+								"value": "no-cache"
+							},
 							{
 								"key": "Content-Type",
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/payerfsp/endpoints",
 							"host": [
@@ -11305,74 +11506,74 @@
 								"endpoints"
 							]
 						},
-						"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+						"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 					},
-					"response": [{
-						"name": "2. Create Initial Position and Limits",
-						"originalRequest": {
-							"method": "POST",
-							"header": [{
-								"key": "Cache-Control",
-								"value": "no-cache"
-							},
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								}
-							],
-							"body": {
-								"mode": "raw",
-								"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
-							},
-							"url": {
-								"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
-								"protocol": "http",
-								"host": [
-									"test-central-ledger",
-									"mojaloop",
-									"live"
+					"response": [
+						{
+							"name": "2. Create Initial Position and Limits",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Cache-Control",
+										"value": "no-cache"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
 								],
-								"path": [
-									"admin",
-									"participants",
-									"testfsp",
-									"initialPositionAndLimits"
-								]
-							}
-						},
-						"status": "OK",
-						"code": 200,
-						"_postman_previewlanguage": "Text",
-						"header": [],
-						"cookie": [],
-						"body": ""
-					}]
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
+								},
+								"url": {
+									"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
+									"protocol": "http",
+									"host": [
+										"{{HOST_CENTRAL_LEDGER}}"
+									],
+									"path": [
+										"participants",
+										"testfsp",
+										"initialPositionAndLimits"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "Text",
+							"header": [],
+							"cookie": [],
+							"body": ""
+						}
+					]
 				},
 				{
 					"name": "Get - limits - All FSPs",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "25e4c348-ec7c-4818-851b-33012759689e",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});"
-							],
-							"type": "text/javascript"
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "25e4c348-ec7c-4818-851b-33012759689e",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
 						}
-					}],
+					],
 					"request": {
 						"method": "GET",
-						"header": [{
-							"key": "FSPIOP-Source",
-							"value": "payerfsp",
-							"type": "text"
-						}],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
+						"header": [
+							{
+								"key": "FSPIOP-Source",
+								"value": "payerfsp",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/limits?currency=USD&type=NET_DEBIT_CAP",
 							"host": [
@@ -11382,10 +11583,11 @@
 								"participants",
 								"limits"
 							],
-							"query": [{
-								"key": "currency",
-								"value": "USD"
-							},
+							"query": [
+								{
+									"key": "currency",
+									"value": "USD"
+								},
 								{
 									"key": "type",
 									"value": "NET_DEBIT_CAP"
@@ -11397,42 +11599,42 @@
 				},
 				{
 					"name": "Get payerfsp position",
-					"event": [{
-						"listen": "test",
-						"script": {
-							"id": "d17ec2ad-d858-4b92-a665-a899f113de1b",
-							"exec": [
-								"pm.test(\"Status code is 200\", function () {",
-								"    pm.response.to.have.status(200);",
-								"});",
-								"",
-								"var jsonData = pm.response.json();",
-								"",
-								"pm.test(\"Atleast one account position should be returned\", function () {",
-								"    pm.variables.set(\"payerfspPositionBeforeTransfer\", jsonData[0].value);",
-								"    pm.expect(jsonData).to.be.not.empty;",
-								"});",
-								"",
-								""
-							],
-							"type": "text/javascript"
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d17ec2ad-d858-4b92-a665-a899f113de1b",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Atleast one account position should be returned\", function () {",
+									"    pm.variables.set(\"payerfspPositionBeforeTransfer\", jsonData[0].value);",
+									"    pm.expect(jsonData).to.be.not.empty;",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					}],
+					],
 					"request": {
 						"auth": {
 							"type": "bearer",
-							"bearer": [{
-								"key": "token",
-								"value": "{{BEARER_TOKEN}}",
-								"type": "string"
-							}]
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BEARER_TOKEN}}",
+									"type": "string"
+								}
+							]
 						},
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{HOST_CENTRAL_LEDGER}}/participants/{{payerfsp}}/positions",
 							"host": [

--- a/OSS-New-Deployment-FSP-Setup.postman_collection.json
+++ b/OSS-New-Deployment-FSP-Setup.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "ba4c8003-b0e6-46b9-8071-523a91d4b4bb",
+		"_postman_id": "11219ff7-896d-4ab0-b7b8-167bbe4cd798",
 		"name": "OSS-New-Deployment-FSP-Setup",
 		"description": "Author: Sridevi Miriyala\nPurpose: Used to add new FSP and relevant Callback Information",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -176,7 +176,7 @@
 								"endpoints"
 							]
 						},
-						"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+						"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 					},
 					"response": [
 						{
@@ -198,12 +198,10 @@
 									"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 								},
 								"url": {
-									"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+									"raw": "http://{{HOST_CENTRAL_LEDGER}}/admin/participants/testfsp/initialPositionAndLimits",
 									"protocol": "http",
 									"host": [
-										"dev1-central-ledger",
-										"mojaloop",
-										"live"
+										"{{HOST_CENTRAL_LEDGER}}"
 									],
 									"path": [
 										"admin",
@@ -275,7 +273,7 @@
 								"endpoints"
 							]
 						},
-						"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+						"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 					},
 					"response": [
 						{
@@ -297,12 +295,10 @@
 									"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 								},
 								"url": {
-									"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+									"raw": "http://{{HOST_CENTRAL_LEDGER}}/admin/participants/testfsp/initialPositionAndLimits",
 									"protocol": "http",
 									"host": [
-										"dev1-central-ledger",
-										"mojaloop",
-										"live"
+										"{{HOST_CENTRAL_LEDGER}}"
 									],
 									"path": [
 										"admin",
@@ -374,7 +370,7 @@
 								"endpoints"
 							]
 						},
-						"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+						"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 					},
 					"response": [
 						{
@@ -396,15 +392,12 @@
 									"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 								},
 								"url": {
-									"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+									"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 									"protocol": "http",
 									"host": [
-										"dev1-central-ledger",
-										"mojaloop",
-										"live"
+										"{{HOST_CENTRAL_LEDGER}}"
 									],
 									"path": [
-										"admin",
 										"participants",
 										"testfsp",
 										"initialPositionAndLimits"
@@ -1051,7 +1044,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -1073,15 +1066,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -1150,7 +1140,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -1172,15 +1162,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -1249,7 +1236,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -1271,15 +1258,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -2036,7 +2020,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2058,15 +2042,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -2135,7 +2116,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2157,15 +2138,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -2234,7 +2212,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2256,15 +2234,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -2669,7 +2644,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2691,15 +2666,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -2768,7 +2740,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2790,15 +2762,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -2867,7 +2836,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2889,15 +2858,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -3302,7 +3268,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -3324,15 +3290,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -3401,7 +3364,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -3423,15 +3386,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -3500,7 +3460,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -3522,15 +3482,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -3935,7 +3892,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -3957,15 +3914,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -4034,7 +3988,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -4056,15 +4010,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -4133,7 +4084,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -4155,15 +4106,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -4568,7 +4516,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -4590,15 +4538,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -4667,7 +4612,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -4689,15 +4634,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -4766,7 +4708,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     {{HOST_CENTRAL_LEDGER}}/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -4788,15 +4730,12 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://{{HOST_CENTRAL_LEDGER}}/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"dev1-central-ledger",
-												"mojaloop",
-												"live"
+												"{{HOST_CENTRAL_LEDGER}}"
 											],
 											"path": [
-												"admin",
 												"participants",
 												"testfsp",
 												"initialPositionAndLimits"
@@ -6346,7 +6285,7 @@
 								"id": "9a37f448-b328-4f61-a481-f5502c463a69",
 								"exec": [
 									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
+									"    pm.response.to.be.success;",
 									"});"
 								],
 								"type": "text/javascript"
@@ -6474,7 +6413,7 @@
 								"id": "9a37f448-b328-4f61-a481-f5502c463a69",
 								"exec": [
 									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
+									"    pm.response.to.be.success;",
 									"});"
 								],
 								"type": "text/javascript"
@@ -6538,7 +6477,7 @@
 								"id": "9a37f448-b328-4f61-a481-f5502c463a69",
 								"exec": [
 									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
+									"    pm.response.to.be.success;",
 									"});"
 								],
 								"type": "text/javascript"
@@ -6602,7 +6541,7 @@
 								"id": "9a37f448-b328-4f61-a481-f5502c463a69",
 								"exec": [
 									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
+									"    pm.response.to.be.success;",
 									"});"
 								],
 								"type": "text/javascript"
@@ -6666,7 +6605,7 @@
 								"id": "9a37f448-b328-4f61-a481-f5502c463a69",
 								"exec": [
 									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
+									"    pm.response.to.be.success;",
 									"});"
 								],
 								"type": "text/javascript"

--- a/OSS-New-Deployment-FSP-Setup.postman_collection.json
+++ b/OSS-New-Deployment-FSP-Setup.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "9921d90d-b46b-41fd-841c-3a6edfc2a048",
+		"_postman_id": "ba4c8003-b0e6-46b9-8071-523a91d4b4bb",
 		"name": "OSS-New-Deployment-FSP-Setup",
 		"description": "Author: Sridevi Miriyala\nPurpose: Used to add new FSP and relevant Callback Information",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -176,7 +176,7 @@
 								"endpoints"
 							]
 						},
-						"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+						"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 					},
 					"response": [
 						{
@@ -198,10 +198,10 @@
 									"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 								},
 								"url": {
-									"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+									"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 									"protocol": "http",
 									"host": [
-										"test-central-ledger",
+										"dev1-central-ledger",
 										"mojaloop",
 										"live"
 									],
@@ -275,7 +275,7 @@
 								"endpoints"
 							]
 						},
-						"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+						"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 					},
 					"response": [
 						{
@@ -297,10 +297,10 @@
 									"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 								},
 								"url": {
-									"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+									"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 									"protocol": "http",
 									"host": [
-										"test-central-ledger",
+										"dev1-central-ledger",
 										"mojaloop",
 										"live"
 									],
@@ -374,7 +374,7 @@
 								"endpoints"
 							]
 						},
-						"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+						"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 					},
 					"response": [
 						{
@@ -396,10 +396,10 @@
 									"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 								},
 								"url": {
-									"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+									"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 									"protocol": "http",
 									"host": [
-										"test-central-ledger",
+										"dev1-central-ledger",
 										"mojaloop",
 										"live"
 									],
@@ -1051,7 +1051,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -1073,10 +1073,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -1150,7 +1150,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -1172,10 +1172,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -1249,7 +1249,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -1271,10 +1271,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -2036,7 +2036,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2058,10 +2058,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -2135,7 +2135,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2157,10 +2157,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -2234,7 +2234,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2256,10 +2256,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -2398,50 +2398,6 @@
 				{
 					"name": "testfsp1 (Only for Settlements testing)",
 					"item": [
-						{
-							"name": "Add testfsp1 - PARTIES, QUOTES",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "b4e2e685-d724-4dad-acae-381abede26f8",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "FSPIOP-Source",
-										"value": "{{testfsp1}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"fspId\":\"testfsp1\",\n  \"baseUrl\":\"{{HOST_SIMULATOR}}/testfsp1\",\n  \"connectorPort\": \"8091\"\n}"
-								},
-								"url": {
-									"raw": "{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}/fsp",
-									"host": [
-										"{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}"
-									],
-									"path": [
-										"fsp"
-									]
-								}
-							},
-							"response": []
-						},
 						{
 							"name": "Add testfsp1 - TRANSFERS",
 							"event": [
@@ -2713,7 +2669,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2735,10 +2691,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -2812,7 +2768,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2834,10 +2790,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -2911,7 +2867,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -2933,10 +2889,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -3075,50 +3031,6 @@
 				{
 					"name": "testfsp2 (Only for Settlements testing)",
 					"item": [
-						{
-							"name": "Add testfsp2 callback - PARTIES, QUOTES",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "b4e2e685-d724-4dad-acae-381abede26f8",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "FSPIOP-Source",
-										"value": "{{testfsp2}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"fspId\":\"testfsp2\",\n  \"baseUrl\":\"{{HOST_SIMULATOR}}/testfsp2\",\n  \"connectorPort\": \"8091\"\n}"
-								},
-								"url": {
-									"raw": "{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}/fsp",
-									"host": [
-										"{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}"
-									],
-									"path": [
-										"fsp"
-									]
-								}
-							},
-							"response": []
-						},
 						{
 							"name": "Add testfsp2 - TRANSFERS",
 							"event": [
@@ -3390,7 +3302,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -3412,10 +3324,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -3489,7 +3401,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -3511,10 +3423,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -3588,7 +3500,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -3610,10 +3522,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -3752,50 +3664,6 @@
 				{
 					"name": "testfsp3 (Only for Settlements testing)",
 					"item": [
-						{
-							"name": "Add testfsp3 callback - PARTIES, QUOTES",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "b4e2e685-d724-4dad-acae-381abede26f8",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "FSPIOP-Source",
-										"value": "{{testfsp1}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"fspId\":\"testfsp3\",\n  \"baseUrl\":\"{{HOST_SIMULATOR}}/testfsp3\",\n  \"connectorPort\": \"8091\"\n}"
-								},
-								"url": {
-									"raw": "{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}/fsp",
-									"host": [
-										"{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}"
-									],
-									"path": [
-										"fsp"
-									]
-								}
-							},
-							"response": []
-						},
 						{
 							"name": "Add testfsp3- TRANSFERS",
 							"event": [
@@ -4067,7 +3935,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -4089,10 +3957,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -4166,7 +4034,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -4188,10 +4056,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -4265,7 +4133,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -4287,10 +4155,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -4429,50 +4297,6 @@
 				{
 					"name": "testfsp4 (Only for Settlements testing)",
 					"item": [
-						{
-							"name": "Add testfsp4 - PARTIES, QUOTES",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "b4e2e685-d724-4dad-acae-381abede26f8",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "FSPIOP-Source",
-										"value": "testfsp4"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"fspId\":\"testfsp4\",\n  \"baseUrl\":\"{{HOST_SIMULATOR}}/testfsp4\",\n  \"connectorPort\": \"8091\"\n}"
-								},
-								"url": {
-									"raw": "{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}/fsp",
-									"host": [
-										"{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}"
-									],
-									"path": [
-										"fsp"
-									]
-								}
-							},
-							"response": []
-						},
 						{
 							"name": "Add testfsp4 - TRANSFERS",
 							"event": [
@@ -4744,7 +4568,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -4766,10 +4590,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -4843,7 +4667,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -4865,10 +4689,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -4942,7 +4766,7 @@
 										"endpoints"
 									]
 								},
-								"description": "Generated from a curl request: \ncurl -i -X POST     http://test-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
+								"description": "Generated from a curl request: \ncurl -i -X POST     http://dev1-central-ledger.mojaloop.test/admin/participants/testfsp2/initialPositionAndLimits     -H 'Cache-Control: no-cache'     -H 'Content-Type: application/json'     -d '{\n    \\\"currency\\\": \\\"USD\\\",\n    \\\"limit\\\": {\n      \\\"type\\\": \\\"NET_DEBIT_CAP\\\",\n      \\\"value\\\": 1000\n    },\n    \\\"initialPosition\\\": 0\n  }'"
 							},
 							"response": [
 								{
@@ -4964,10 +4788,10 @@
 											"raw": "{\n    \"currency\": \"USD\",\n    \"limit\": {\n      \"type\": \"NET_DEBIT_CAP\",\n      \"value\": 1000\n    },\n    \"initialPosition\": 0\n  }"
 										},
 										"url": {
-											"raw": "http://test-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
+											"raw": "http://dev1-central-ledger.mojaloop.live/admin/participants/testfsp/initialPositionAndLimits",
 											"protocol": "http",
 											"host": [
-												"test-central-ledger",
+												"dev1-central-ledger",
 												"mojaloop",
 												"live"
 											],
@@ -6310,7 +6134,7 @@
 							},
 							{
 								"key": "Date",
-								"value": ""
+								"value": "{{transferDate}}"
 							},
 							{
 								"key": "FSPIOP-Source",
@@ -6370,7 +6194,7 @@
 							},
 							{
 								"key": "Date",
-								"value": ""
+								"value": "{{transferDate}}"
 							},
 							{
 								"key": "FSPIOP-Source",
@@ -6430,7 +6254,7 @@
 							},
 							{
 								"key": "Date",
-								"value": ""
+								"value": "{{transferDate}}"
 							},
 							{
 								"key": "FSPIOP-Source",
@@ -6498,7 +6322,7 @@
 			]
 		},
 		{
-			"name": "Add Users to mock-pathfinder",
+			"name": "Add Users to ALS / mock-pathfinder",
 			"item": [
 				{
 					"name": "Add 27713803910 to payerfsp",
@@ -6537,6 +6361,10 @@
 								"value": "application/json"
 							},
 							{
+								"key": "Date",
+								"value": "{{transferDate}}"
+							},
+							{
 								"key": "FSPIOP-Source",
 								"value": "{{payerfsp}}"
 							}
@@ -6546,9 +6374,9 @@
 							"raw": "{\n \"fspId\": \"{{payerfsp}}\",\n \"currency\": \"USD\"\n}\n"
 						},
 						"url": {
-							"raw": "{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}/participants/MSISDN/27713803910",
+							"raw": "{{HOST_ACCOUNT_LOOKUP_SERVICE}}/participants/MSISDN/27713803910",
 							"host": [
-								"{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}"
+								"{{HOST_ACCOUNT_LOOKUP_SERVICE}}"
 							],
 							"path": [
 								"participants",
@@ -6581,8 +6409,8 @@
 							"script": {
 								"id": "9a37f448-b328-4f61-a481-f5502c463a69",
 								"exec": [
-									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
+									"pm.test(\"Status code is 202 or 200\", function () {",
+									"    pm.response.to.be.success;",
 									"});"
 								],
 								"type": "text/javascript"
@@ -6597,6 +6425,10 @@
 								"value": "application/json"
 							},
 							{
+								"key": "Date",
+								"value": "{{transferDate}}"
+							},
+							{
 								"key": "FSPIOP-Source",
 								"value": "{{payerfsp}}"
 							}
@@ -6606,9 +6438,9 @@
 							"raw": "{\n \"fspId\": \"{{payerfsp}}\",\n \"currency\": \"USD\"\n}\n"
 						},
 						"url": {
-							"raw": "{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}/participants/MSISDN/27713803911",
+							"raw": "{{HOST_ACCOUNT_LOOKUP_SERVICE}}/participants/MSISDN/27713803911",
 							"host": [
-								"{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}"
+								"{{HOST_ACCOUNT_LOOKUP_SERVICE}}"
 							],
 							"path": [
 								"participants",
@@ -6657,6 +6489,10 @@
 								"value": "application/json"
 							},
 							{
+								"key": "Date",
+								"value": "{{transferDate}}"
+							},
+							{
 								"key": "FSPIOP-Source",
 								"value": "{{payeefsp}}"
 							}
@@ -6666,9 +6502,9 @@
 							"raw": "{\n \"fspId\": \"{{payeefsp}}\",\n \"currency\": \"USD\"\n}\n"
 						},
 						"url": {
-							"raw": "{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}/participants/MSISDN/27713803912",
+							"raw": "{{HOST_ACCOUNT_LOOKUP_SERVICE}}/participants/MSISDN/27713803912",
 							"host": [
-								"{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}"
+								"{{HOST_ACCOUNT_LOOKUP_SERVICE}}"
 							],
 							"path": [
 								"participants",
@@ -6717,6 +6553,10 @@
 								"value": "application/json"
 							},
 							{
+								"key": "Date",
+								"value": "{{transferDate}}"
+							},
+							{
 								"key": "FSPIOP-Source",
 								"value": "{{payeefsp}}"
 							}
@@ -6726,9 +6566,9 @@
 							"raw": "{\n \"fspId\": \"{{payeefsp}}\",\n \"currency\": \"USD\"\n}\n"
 						},
 						"url": {
-							"raw": "{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}/participants/MSISDN/{{pathfinderMSISDN}}",
+							"raw": "{{HOST_ACCOUNT_LOOKUP_SERVICE}}/participants/MSISDN/{{pathfinderMSISDN}}",
 							"host": [
-								"{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}"
+								"{{HOST_ACCOUNT_LOOKUP_SERVICE}}"
 							],
 							"path": [
 								"participants",
@@ -6777,6 +6617,10 @@
 								"value": "application/json"
 							},
 							{
+								"key": "Date",
+								"value": "{{transferDate}}"
+							},
+							{
 								"key": "FSPIOP-Source",
 								"value": "{{payeefsp}}"
 							}
@@ -6786,9 +6630,9 @@
 							"raw": "{\n \"fspId\": \"{{payeefsp}}\",\n \"currency\": \"USD\"\n}\n"
 						},
 						"url": {
-							"raw": "{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}/participants/MSISDN/27713803913",
+							"raw": "{{HOST_ACCOUNT_LOOKUP_SERVICE}}/participants/MSISDN/27713803913",
 							"host": [
-								"{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}"
+								"{{HOST_ACCOUNT_LOOKUP_SERVICE}}"
 							],
 							"path": [
 								"participants",
@@ -6837,6 +6681,10 @@
 								"value": "application/json"
 							},
 							{
+								"key": "Date",
+								"value": "{{transferDate}}"
+							},
+							{
 								"key": "FSPIOP-Source",
 								"value": "{{payeefsp}}"
 							}
@@ -6846,9 +6694,9 @@
 							"raw": "{\n \"fspId\": \"{{payeefsp}}\",\n \"currency\": \"USD\"\n}\n"
 						},
 						"url": {
-							"raw": "{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}/participants/MSISDN/27713803914",
+							"raw": "{{HOST_ACCOUNT_LOOKUP_SERVICE}}/participants/MSISDN/27713803914",
 							"host": [
-								"{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}"
+								"{{HOST_ACCOUNT_LOOKUP_SERVICE}}"
 							],
 							"path": [
 								"participants",
@@ -6882,7 +6730,7 @@
 								"id": "9a37f448-b328-4f61-a481-f5502c463a69",
 								"exec": [
 									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
+									"    pm.response.to.be.success;",
 									"});"
 								],
 								"type": "text/javascript"
@@ -6897,6 +6745,10 @@
 								"value": "application/json"
 							},
 							{
+								"key": "Date",
+								"value": "{{transferDate}}"
+							},
+							{
 								"key": "FSPIOP-Source",
 								"value": "{{payeefsp}}"
 							}
@@ -6906,9 +6758,9 @@
 							"raw": "{\n \"fspId\": \"{{payeefsp}}\",\n \"currency\": \"USD\"\n}\n"
 						},
 						"url": {
-							"raw": "{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}/participants/MSISDN/27713803915",
+							"raw": "{{HOST_ACCOUNT_LOOKUP_SERVICE}}/participants/MSISDN/27713803915",
 							"host": [
-								"{{HOST_SWITCH}}{{BASE_PATH_SWITCH}}"
+								"{{HOST_ACCOUNT_LOOKUP_SERVICE}}"
 							],
 							"path": [
 								"participants",


### PR DESCRIPTION
Changes include [to _OSS-New-Deployment-FSP-Setup_ collection]
- updating params, adding Date header to missing requests
- changing URLs to update 'test' to 'dev1' to point to dev1 instead of dev0]
- parameterized host names in several places that were causing failures on the dev1 runs
- Updated the Golden path collection, disabled tests that are not getting responses from simulator for the time being
   - Updated host names where relevant 
   - Removed tests where there is no response (even separately) from the simulator