### PR TITLE
Add the missing HOST_TRANSACTION_REQUESTS_SERVICE variable

### DIFF
--- a/environments/Mojaloop-Local.postman_environment.json
+++ b/environments/Mojaloop-Local.postman_environment.json
@@ -771,6 +771,11 @@
 			"key": "HOST_BULK_API_ADAPTER",
 			"value": "http://localhost:3003",
 			"enabled": true
+		},
+		{
+			"key": "HOST_TRANSACTION_REQUESTS_SERVICE",
+			"value": "http://transaction-request-service.local",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",


### PR DESCRIPTION
I wasn't sure what this should be for the `Mojaloop-Local-Docker-Compose.postman_environment.json` file, but can someone please refer me to the right place and I can add it?

