### PR TITLE
Fixed the authorizations Accept and Content-Type values

### DIFF
--- a/Golden_Path.postman_collection.json
+++ b/Golden_Path.postman_collection.json
@@ -2,7 +2,7 @@
 	"info": {
 		"_postman_id": "dd97a25f-d1a0-46d5-bc66-9926cbab597a",
 		"name": "Golden_Path",
-		"description": "Purpose: To setup a newly deployed Mojaloop Switch and add test FSPs along with their callback and other Information needed for end-to-end testing.\n\nContributors:\n- Mowali\n- Amar Ramachandran <amarnath.ramachandran@modusbox.com>\n- Georgi Georgiev <georgi.georgiev@modusbox.com>\n- Juan Correa <juan.correa@modusbox.com>\n- Miguel deBarros <miguel.debarros@modusbox.com>\n- Nico Duvenage <nico.duvenage@modusbox.com>\n- Sam Kummary <sam@modusbox.com>\n- Sri Miryala <sridevi.miriyala@modusbox.com>\n- Steven Oderayi <steven.oderayi@modusbox.com>\n- valentin genev <valentin.genev@modusbox.com>\n- Vijay Guthi <vijaya.guthi@modusbox.com>",
+		"description": "Purpose: To setup a newly deployed Mojaloop Switch and add test FSPs along with their callback and other Information needed for end-to-end testing.\n\nContributors:\n- Mowali\n- Amar Ramachandran <amarnath.ramachandran@modusbox.com>\n- Georgi Georgiev <georgi.georgiev@modusbox.com>\n- Juan Correa <juan.correa@modusbox.com>\n- Miguel deBarros <miguel.debarros@modusbox.com>\n- Nico Duvenage <nico.duvenage@modusbox.com>\n- Sam Kummary <sam@modusbox.com>\n- Sri Miryala <sridevi.miriyala@modusbox.com>\n- Steven Oderayi <steven.oderayi@modusbox.com>\n- valentin genev <valentin.genev@modusbox.com>\n- Vijay Guthi <vijaya.guthi@modusbox.com>\n- Adrian Enns <adrian.enns@modusbox.com>",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -14281,12 +14281,12 @@
 								"header": [
 									{
 										"key": "Accept",
-										"value": "application/vnd.interoperability.transactionRequests+json;version=1",
+										"value": "application/vnd.interoperability.authorizations+json;version=1",
 										"type": "text"
 									},
 									{
 										"key": "Content-Type",
-										"value": "application/vnd.interoperability.transactionRequests+json;version=1.0",
+										"value": "application/vnd.interoperability.authorizations+json;version=1.0",
 										"type": "text"
 									},
 									{
@@ -14387,12 +14387,12 @@
 								"header": [
 									{
 										"key": "Accept",
-										"value": "application/vnd.interoperability.transactionRequests+json;version=1",
+										"value": "application/vnd.interoperability.authorizations+json;version=1",
 										"type": "text"
 									},
 									{
 										"key": "Content-Type",
-										"value": "application/vnd.interoperability.transactionRequests+json;version=1.0",
+										"value": "application/vnd.interoperability.authorizations+json;version=1.0",
 										"type": "text"
 									},
 									{


### PR DESCRIPTION
This fixes the GoldenPath PUT/GET requests for the /authorizations/{ID} endpoints. The Accept and Content-Type headers were fixed for both methods.