### PR TITLE
Fixed path for testing missing param

### DIFF
--- a/Golden_Path.postman_collection.json
+++ b/Golden_Path.postman_collection.json
@@ -18417,12 +18417,13 @@
 							"raw": "{\n  \"fulfilment\": \"{{validFulfillment}}\",\n  \"completedTimestamp\": \"{{completedTimestamp}}\",\n  \"transferState\": \"COMMITTED\"\n}"
 						},
 						"url": {
-							"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers",
+							"raw": "{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}/transfers/",
 							"host": [
 								"{{HOST_SWITCH_TRANSFERS}}{{BASE_PATH_SWITCH_TRANSFERS}}"
 							],
 							"path": [
-								"transfers"
+								"transfers",
+								""
 							]
 						}
 					},


### PR DESCRIPTION
For PUT /transfers the switch is responding with error code 3000 "Generic client error - Method Not Allowed"
For PUT /transfers/ the switch is returning 3002 "Unknown URI - Not Found"

For checking missing ID we have to send PUT /transfers/ not PUT /transfers.