### PR TITLE
fix(#2265): validating a mojaloop deployment as described in the documentation is failing

### DIFF
--- a/environments/Mojaloop-Local-MojaSims.postman_environment.json
+++ b/environments/Mojaloop-Local-MojaSims.postman_environment.json
@@ -54,12 +54,12 @@
 		},
 		{
 			"key": "HOST_CENTRAL_SETTLEMENT",
-			"value": "http://central-settlement.local",
+			"value": "http://central-settlement-service.local",
 			"enabled": true
 		},
 		{
 			"key": "BASE_CENTRAL_SETTLEMENT",
-			"value": "/v1",
+			"value": "/v2",
 			"enabled": true
 		},
 		{


### PR DESCRIPTION
- Fixed Central-settlement ingress host name and base URI in Local Mojaloop Values